### PR TITLE
Enable CI with github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
      - uses: mymindstorm/setup-emsdk@v11
      - name: Get sources
        run: |
+         sudo apt-get install -y bzr
          ./get_sources
      - name: emscriptem bndings
      - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,12 @@
 name: My Workflow
 
-on: [push]
-
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   runMultipleCommands:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,4 +38,4 @@ jobs:
            sudo apt-get install nodejs npm
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
            npm install
-           npm test       
+           npm test -sEXIT_RUNTIME=1       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
      - uses: actions/checkout@v3  
      - name: Install dependencies
        run: |
-         sudo apt-get install -y bzr cmake
+         sudo apt-get install -y bzr cmake libz-dev
          ./get_sources
      - uses: mymindstorm/setup-emsdk@v11     
      - name: Create emscripten bindings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,31 +10,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
        - uses: actions/checkout@v1
-       - name: Install dependencies
+       - name: Rename folder
          run: |
-           sudo apt-get install -y bzr cmake libz-dev nodejs npm git
-           cd /home/runner/work/CCP4-Web-Assembly/
-           git clone https://github.com/emscripten-core/emsdk.git
-           cd /home/runner/work/CCP4-Web-Assembly/emsdk
-           ./emsdk install latest
-           ./emsdk activate latest
-           source ./emsdk_env.sh  
            cd /home/runner/work/CCP4-Web-Assembly/
            mv CCP4-Web-Assembly ccp4_wasm
        - name: Download sources
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-         run: |         
+         run: |
+           sudo apt-get install -y bzr
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
            ./get_sources
        - name: emscripten bindings
-         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
-         run: |       
+         working-directory: /home/runner/work/CCP4-Web-Assembly/       
+         run: |    
+           cd /home/runner/work/CCP4-Web-Assembly/
+           git clone https://github.com/emscripten-core/emsdk.git
+           cd /home/runner/work/CCP4-Web-Assembly/emsdk/
+           ./emsdk install latest
+           ./emsdk activate latest
+           source ./emsdk_env.sh  
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm         
            emcmake cmake .
            emmake make
        - name: Run tests
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
-         run: |                               
+         run: |             
+           sudo apt-get install nodejs npm
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
            npm install
            npm test       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,6 @@ jobs:
                cd /home/runner/work/CCP4-Web-Assembly/
                mv CCP4-Web-Assembly ccp4_wasm
        - name: Three     
-         working-directory: /home/runner/work/CCP4-Web-Assembly/
+         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
          run:  ls
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,13 @@ jobs:
          run: | 
                cd /home/runner/work/CCP4-Web-Assembly/
                mv CCP4-Web-Assembly ccp4_wasm
+       - name: Two     
+         working-directory: /home/runner/work/
+         run:  ls
        - name: Three     
+         working-directory: /home/runner/work/CCP4-Web-Assembly/
+         run:  ls
+       - name: Four     
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
          run:  ls
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,4 +33,4 @@ jobs:
          run: |             
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
            npm install
-           npm test -sEXIT_RUNTIME=1 
+           npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v3  
+     - uses: mymindstorm/setup-emsdk@v11
+     - uses: actions/setup-node@v3
      - name: Run tests
        run: |
          sudo apt-get install -y bzr cmake libz-dev nodejs npm git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-name: Build and Test
-
 on:
   push:
     branches:
@@ -7,28 +5,28 @@ on:
   pull_request:
     branches:
       - master
-
 jobs:
   runTests:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v3  
-     - uses: mymindstorm/setup-emsdk@v11
-     - uses: actions/setup-node@v3
-     - name: Run tests
+     - name: Install dependencies
        run: |
-         sudo apt-get install -y bzr cmake libz-dev nodejs npm git
-         git clone https://github.com/emscripten-core/emsdk.git
-         cd emsdk
-         ./emsdk install latest
-         ./emsdk activate latest
-         source ./emsdk_env.sh  
-         cd ../..
+         sudo apt-get install -y bzr cmake libz-dev
+         cd ..
          mv CCP4-Web-Assembly ccp4_wasm
          cd ccp4_wasm
          ./get_sources
+     - uses: mymindstorm/setup-emsdk@v11     
+     - name: Create emscripten bindings
+       working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+       run: |
          emcmake cmake .
          emmake make
+     - uses: actions/setup-node@v3
+     - name: Run tests
+       working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+       run: |
          cd tests
          npm install
          npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,12 @@ jobs:
            #source ./emsdk_env.sh  
            #cd /home/runner/work/CCP4-Web-Assembly/
            mv CCP4-Web-Assembly ccp4_wasm
-           ls ccp4_wasm
+           echo $(ls ccp4_wasm)
        - name: Download sources
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
          run: |         
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-           ls 
+           echo $(ls  $pwd)
            #./get_sources
        - name: emscripten bindings
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,5 @@ jobs:
                mv CCP4-Web-Assembly ccp4_wasm
        - name: Three     
          working-directory: /home/runner/work/CCP4-Web-Assembly/
-         run:  echo "::set-output name=mix-test::$(ls ccp4_wasm)" 
-       - name: Four    
-         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm    
-         run:  echo "::set-output name=mix-test::$( pwd )"
+         run:  ls
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,13 @@ jobs:
   runTests:
     runs-on: ubuntu-latest
     steps:
-       - name: Install dependencies
-       - run: cd /home/runner/work/CCP4-Web-Assembly/
-       - run:  mv CCP4-Web-Assembly ccp4_wasm
-       - run:  echo $(ls ccp4_wasm)
-       - run:  cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-       - run:  echo $(ls  $pwd)
+       - name: One
+         run: cd /home/runner/work/CCP4-Web-Assembly/
+       - name: Two
+         run:  mv CCP4-Web-Assembly ccp4_wasm
+       - name: Three     
+         run:  echo $(ls ccp4_wasm)
+       - name: Four       
+         run:  cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+       - name: Five       
+         run:  echo $(ls  $pwd)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,21 +9,27 @@ jobs:
   runTests:
     runs-on: ubuntu-latest
     steps:
-       name: Run tests
-       run: |
-         sudo apt-get install -y bzr cmake libz-dev nodejs npm git
-         cd /home/runner/work/CCP4-Web-Assembly/
-         git clone https://github.com/emscripten-core/emsdk.git
-         cd /home/runner/work/CCP4-Web-Assembly/emsdk
-         ./emsdk install latest
-         ./emsdk activate latest
-         source ./emsdk_env.sh  
-         cd /home/runner/work/CCP4-Web-Assembly/
-         mv CCP4-Web-Assembly ccp4_wasm
-         cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-         ./get_sources
-         emcmake cmake .
-         emmake make
-         cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
-         npm install
-         npm test
+       - name: Install dependencies
+         run: |
+           sudo apt-get install -y bzr cmake libz-dev nodejs npm git
+           cd /home/runner/work/CCP4-Web-Assembly/
+           git clone https://github.com/emscripten-core/emsdk.git
+           cd /home/runner/work/CCP4-Web-Assembly/emsdk
+           ./emsdk install latest
+           ./emsdk activate latest
+           source ./emsdk_env.sh  
+           cd /home/runner/work/CCP4-Web-Assembly/
+           mv CCP4-Web-Assembly ccp4_wasm
+       - name: Download sources
+         run: |         
+           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+           ./get_sources
+       - name: emscripten bindings
+         run: |                    
+           emcmake cmake .
+           emmake make
+       - name: Run tests
+         run: |                               
+           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
+           npm install
+           npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,13 +19,13 @@ jobs:
          ./get_sources
      - uses: mymindstorm/setup-emsdk@v11     
      - name: Create emscripten bindings
-       working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+     - working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
        run: |
          emcmake cmake .
          emmake make
      - uses: actions/setup-node@v3
      - name: Run tests
-       working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+     - working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
        run: |
          cd tests
          npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
        - name: One
-         run: cd /home/runner/work/CCP4-Web-Assembly/
-       - name: Two
-         run:  mv CCP4-Web-Assembly ccp4_wasm
+         run: | 
+               cd /home/runner/work/CCP4-Web-Assembly/
+               mv CCP4-Web-Assembly ccp4_wasm
        - name: Three     
+         working-directory: /home/runner/work/CCP4-Web-Assembly/
          run:  echo $(ls ccp4_wasm)
-       - name: Four       
-         run:  cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-       - name: Five       
+       - name: Four    
+         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm    
          run:  echo $(ls  $pwd)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,32 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
        - name: Install dependencies
-         run: |
-           #sudo apt-get install -y bzr cmake libz-dev nodejs npm git
-           cd /home/runner/work/CCP4-Web-Assembly/
-           #git clone https://github.com/emscripten-core/emsdk.git
-           #cd /home/runner/work/CCP4-Web-Assembly/emsdk
-           #./emsdk install latest
-           #./emsdk activate latest
-           #source ./emsdk_env.sh  
-           #cd /home/runner/work/CCP4-Web-Assembly/
-           mv CCP4-Web-Assembly ccp4_wasm
-           echo $(ls ccp4_wasm)
-       - name: Download sources
-         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-         run: |         
-           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-           echo $(ls  $pwd)
-           #./get_sources
-       - name: emscripten bindings
-         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
-         run: |       
-           #cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm         
-           #emcmake cmake .
-           #emmake make
-       - name: Run tests
-         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
-         run: |                               
-           #cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
-           #npm install
-           #npm test
+       - run: cd /home/runner/work/CCP4-Web-Assembly/
+       - run:  mv CCP4-Web-Assembly ccp4_wasm
+       - run:  echo $(ls ccp4_wasm)
+       - run:  cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+       - run:  echo $(ls  $pwd)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
          emmake make
      - uses: actions/setup-node@v3
      - name: Run tests
-     - run: |
+       run: |
          cd reac_app
          npm test
          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
      - name: Install dependencies
        run: |
          sudo apt-get install -y bzr cmake libz-dev
+         cd ..
+         mv CCP4-Web-Assembly ccp4_wasm
+         cd ccp4_wasm
          ./get_sources
      - uses: mymindstorm/setup-emsdk@v11     
      - name: Create emscripten bindings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,24 +11,24 @@ on:
 jobs:
   runTests:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./ccp4_wasm    
     steps:
      - uses: actions/checkout@v3  
      - name: Install dependencies
        run: |
-         sudo apt-get install -y bzr cmake libz-dev
-         cd ..
+         sudo apt-get install -y bzr cmake libz-dev nodejs npm git
+         git clone https://github.com/emscripten-core/emsdk.git
+         cd emsdk
+         ./emsdk install latest
+         ./emsdk activate latest
+         source ./emsdk_env.sh  
+         cd ../..
          mv CCP4-Web-Assembly ccp4_wasm
          cd ccp4_wasm
          ./get_sources
-     - uses: mymindstorm/setup-emsdk@v11     
      - name: Create emscripten bindings
        run: |
          emcmake cmake .
          emmake make
-     - uses: actions/setup-node@v3
      - name: Run tests
        run: |
          cd tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,4 @@ jobs:
          run:  echo "::set-output name=mix-test::$(ls ccp4_wasm)" 
        - name: Four    
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm    
-         run:  echo "::set-output name=mix-test::$(ls  $pwd)
-"
+         run:  echo "::set-output name=mix-test::$( pwd )"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
      - uses: mymindstorm/setup-emsdk@v11
      - name: Get sources
        run: |
-         sudo apt-get install -y bzr
+         sudo apt-get install -y bzr cmake
          ./get_sources
      - name: emscriptem bndings
      - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: My Workflow
+
+on: [push]
+
+jobs:
+  runMultipleCommands:
+    runs-on: ubuntu-latest
+    steps:
+     - uses: actions/checkout@v3
+     - uses: actions/setup-node@v3
+     - uses: mymindstorm/setup-emsdk@v11
+     - run: |
+        ./get_sources
+        emcmake cmake .
+        emmake make
+        cd react-app
+     - run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,7 @@
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  schedule:
+  - cron: "0 0 * * *"
+  
 jobs:
   runTests:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,32 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
        - uses: actions/checkout@v1
-       - name: Rename folder
+       - name: Run tests
          run: |
+           sudo apt-get install -y bzr nodejs npm         
            cd /home/runner/work/CCP4-Web-Assembly/
            mv CCP4-Web-Assembly ccp4_wasm
-       - name: Download sources
-         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-         run: |
-           sudo apt-get install -y bzr
-           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-           ./get_sources
-       - name: emscripten bindings
-         working-directory: /home/runner/work/CCP4-Web-Assembly/       
-         run: |    
-           cd /home/runner/work/CCP4-Web-Assembly/
            git clone https://github.com/emscripten-core/emsdk.git
            cd /home/runner/work/CCP4-Web-Assembly/emsdk/
            ./emsdk install latest
            ./emsdk activate latest
-           source ./emsdk_env.sh  
-           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm         
+           source ./emsdk_env.sh             
+           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+           ./get_sources
            emcmake cmake .
            emmake make
-       - name: Run tests
-         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
-         run: |             
-           sudo apt-get install nodejs npm
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
            npm install
            npm test -sEXIT_RUNTIME=1       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,24 +9,21 @@ jobs:
   runTests:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v3  
-     - name: Install dependencies
+       name: Run tests
        run: |
-         sudo apt-get install -y bzr cmake libz-dev
-         cd ..
+         sudo apt-get install -y bzr cmake libz-dev nodejs npm git
+         cd /home/runner/work/CCP4-Web-Assembly/
+         git clone https://github.com/emscripten-core/emsdk.git
+         cd /home/runner/work/CCP4-Web-Assembly/emsdk
+         ./emsdk install latest
+         ./emsdk activate latest
+         source ./emsdk_env.sh  
+         cd /home/runner/work/CCP4-Web-Assembly/
          mv CCP4-Web-Assembly ccp4_wasm
-         cd ccp4_wasm
+         cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
          ./get_sources
-     - uses: mymindstorm/setup-emsdk@v11     
-     - name: Create emscripten bindings
-     - working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-       run: |
          emcmake cmake .
          emmake make
-     - uses: actions/setup-node@v3
-     - name: Run tests
-     - working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-       run: |
-         cd tests
+         cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
          npm install
          npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,8 @@ jobs:
                mv CCP4-Web-Assembly ccp4_wasm
        - name: Three     
          working-directory: /home/runner/work/CCP4-Web-Assembly/
-         run:  echo $(ls ccp4_wasm)
+         run:  echo "::set-output name=mix-test::$(ls ccp4_wasm)" 
        - name: Four    
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm    
-         run:  echo $(ls  $pwd)
+         run:  echo "::set-output name=mix-test::$(ls  $pwd)
+"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,16 +7,23 @@ on:
   pull_request:
     branches:
       - master
+
 jobs:
-  runMultipleCommands:
+  runTests:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v3
      - uses: actions/setup-node@v3
      - uses: mymindstorm/setup-emsdk@v11
+     - name: Get sources
+       run: |
+         ./get_sources
+     - name: emscriptem bndings
      - run: |
-        ./get_sources
-        emcmake cmake .
-        emmake make
-        cd react-app
-     - run: npm test
+         emcmake cmake .
+         emmake make
+     - name: Run tests
+     - run: |
+         cd reac_app
+         npm test
+         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,17 +12,17 @@ jobs:
   runTests:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v3
-     - uses: actions/setup-node@v3
-     - uses: mymindstorm/setup-emsdk@v11
-     - name: Get sources
+     - uses: actions/checkout@v3  
+     - name: Install dependencies
        run: |
          sudo apt-get install -y bzr cmake
          ./get_sources
-     - name: emscriptem bndings
-     - run: |
+     - uses: mymindstorm/setup-emsdk@v11     
+     - name: Create emscripten bindings
+       run: |
          emcmake cmake .
          emmake make
+     - uses: actions/setup-node@v3
      - name: Run tests
      - run: |
          cd reac_app

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,20 +10,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
        - uses: actions/checkout@v1
-       - name: Run tests
+       - name: Rename folder
          run: |
-           sudo apt-get install -y bzr nodejs npm         
            cd /home/runner/work/CCP4-Web-Assembly/
            mv CCP4-Web-Assembly ccp4_wasm
+       - name: Install dependencies 
+         working-directory: /home/runner/work/CCP4-Web-Assembly/       
+         run: |    
+           sudo apt-get install -y bzr nodejs npm                  
+           cd /home/runner/work/CCP4-Web-Assembly/
            git clone https://github.com/emscripten-core/emsdk.git
            cd /home/runner/work/CCP4-Web-Assembly/emsdk/
            ./emsdk install latest
            ./emsdk activate latest
-           source ./emsdk_env.sh             
-           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+       - name: Download sources and create bindings
+         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+         run: |
+           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm         
+           source /home/runner/work/CCP4-Web-Assembly/emsdk/emsdk_env.sh  
            ./get_sources
            emcmake cmake .
            emmake make
+       - name: Run tests
+         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
+         run: |             
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
            npm install
-           npm test -sEXIT_RUNTIME=1       
+           npm test -sEXIT_RUNTIME=1 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v3  
-     - name: Install dependencies
+     - name: Run tests
        run: |
          sudo apt-get install -y bzr cmake libz-dev nodejs npm git
          git clone https://github.com/emscripten-core/emsdk.git
@@ -25,13 +25,8 @@ jobs:
          mv CCP4-Web-Assembly ccp4_wasm
          cd ccp4_wasm
          ./get_sources
-     - name: Create emscripten bindings
-       run: |
          emcmake cmake .
          emmake make
-     - name: Run tests
-       run: |
          cd tests
          npm install
          npm test
-         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: My Workflow
+name: Build and Test
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
        - name: One
-         run: | 
-               cd /home/runner/work/CCP4-Web-Assembly/
-               mv CCP4-Web-Assembly ccp4_wasm
+         run: ls
        - name: Two     
          working-directory: /home/runner/work/
          run:  ls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,13 @@ jobs:
          ./get_sources
      - uses: mymindstorm/setup-emsdk@v11     
      - name: Create emscripten bindings
+       working-directory: ./ccp4_wasm
        run: |
          emcmake cmake .
          emmake make
      - uses: actions/setup-node@v3
      - name: Run tests
+       working-directory: ./ccp4_wasm     
        run: |
          cd tests
          npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,15 +9,32 @@ jobs:
   runTests:
     runs-on: ubuntu-latest
     steps:
-       - name: One
-         run: ls
-       - name: Two     
-         working-directory: /home/runner/work/
-         run:  ls
-       - name: Three     
-         working-directory: /home/runner/work/CCP4-Web-Assembly/
-         run:  ls
-       - name: Four     
+       - uses: actions/checkout@v1
+       - name: Install dependencies
+         run: |
+           sudo apt-get install -y bzr cmake libz-dev nodejs npm git
+           cd /home/runner/work/CCP4-Web-Assembly/
+           git clone https://github.com/emscripten-core/emsdk.git
+           cd /home/runner/work/CCP4-Web-Assembly/emsdk
+           ./emsdk install latest
+           ./emsdk activate latest
+           source ./emsdk_env.sh  
+           cd /home/runner/work/CCP4-Web-Assembly/
+           mv CCP4-Web-Assembly ccp4_wasm
+       - name: Download sources
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-         run:  ls
-
+         run: |         
+           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
+           ./get_sources
+       - name: emscripten bindings
+         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
+         run: |       
+           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm         
+           emcmake cmake .
+           emmake make
+       - name: Run tests
+         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
+         run: |                               
+           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
+           npm install
+           npm test       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   runTests:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ccp4_wasm    
     steps:
      - uses: actions/checkout@v3  
      - name: Install dependencies
@@ -22,13 +25,11 @@ jobs:
          ./get_sources
      - uses: mymindstorm/setup-emsdk@v11     
      - name: Create emscripten bindings
-       working-directory: ./ccp4_wasm
        run: |
          emcmake cmake .
          emmake make
      - uses: actions/setup-node@v3
      - name: Run tests
-       working-directory: ./ccp4_wasm     
        run: |
          cd tests
          npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,14 +21,18 @@ jobs:
            cd /home/runner/work/CCP4-Web-Assembly/
            mv CCP4-Web-Assembly ccp4_wasm
        - name: Download sources
+         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
          run: |         
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
            ./get_sources
        - name: emscripten bindings
-         run: |                    
+         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
+         run: |       
+           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm         
            emcmake cmake .
            emmake make
        - name: Run tests
+         working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
          run: |                               
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
            npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
      - uses: actions/setup-node@v3
      - name: Run tests
        run: |
-         cd reac_app
+         cd tests
+         npm install
          npm test
          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,29 +11,31 @@ jobs:
     steps:
        - name: Install dependencies
          run: |
-           sudo apt-get install -y bzr cmake libz-dev nodejs npm git
+           #sudo apt-get install -y bzr cmake libz-dev nodejs npm git
            cd /home/runner/work/CCP4-Web-Assembly/
-           git clone https://github.com/emscripten-core/emsdk.git
-           cd /home/runner/work/CCP4-Web-Assembly/emsdk
-           ./emsdk install latest
-           ./emsdk activate latest
-           source ./emsdk_env.sh  
-           cd /home/runner/work/CCP4-Web-Assembly/
+           #git clone https://github.com/emscripten-core/emsdk.git
+           #cd /home/runner/work/CCP4-Web-Assembly/emsdk
+           #./emsdk install latest
+           #./emsdk activate latest
+           #source ./emsdk_env.sh  
+           #cd /home/runner/work/CCP4-Web-Assembly/
            mv CCP4-Web-Assembly ccp4_wasm
+           ls ccp4_wasm
        - name: Download sources
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
          run: |         
            cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm
-           ./get_sources
+           ls 
+           #./get_sources
        - name: emscripten bindings
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
          run: |       
-           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm         
-           emcmake cmake .
-           emmake make
+           #cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm         
+           #emcmake cmake .
+           #emmake make
        - name: Run tests
          working-directory: /home/runner/work/CCP4-Web-Assembly/ccp4_wasm       
          run: |                               
-           cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
-           npm install
-           npm test
+           #cd /home/runner/work/CCP4-Web-Assembly/ccp4_wasm/tests
+           #npm install
+           #npm test


### PR DESCRIPTION
This will run the tests every day at midnight on the latest commit. Currently fails at `emmake make` stage but once the undefined reference from coot is patched then it should be fine.