### PR TITLE
Use promises to comunicate between widgets and cryst worker

### DIFF
--- a/react-app/src/FlipPeptide.js
+++ b/react-app/src/FlipPeptide.js
@@ -10,6 +10,9 @@ import {parsePDB} from './mgMiniMol.js';
 
 import { guid } from './guid.js';
 
+/**
+ * React component to handle flip peptides task
+ */
 class FlipPeptide extends Component {
     constructor(props) {
 
@@ -18,19 +21,48 @@ class FlipPeptide extends Component {
 
         this.preRef = React.createRef();
 
-        this.state = {selected:"unk",mapSelected:"unk",log:"", chainId:"", flipRes:0 };
+        this.state = {selected:"unk", mapSelected:"unk", log:"", chainId:"", flipRes:0 };
         this.jobData = {};
         this.message = "";
         const self = this;
     }
 
+    /**
+     * Sends a message to crystallography worker as a promise
+     * @param {Worker} crystWorker 
+     * @param {Object} kwargs 
+     */
+    postCrystWorkerMessage(crystWorker, kwargs) {
+        console.log(crystWorker);
+        const messageId = guid();
+        return new Promise((resolve, reject) => {
+            const messageListener = crystWorker.addEventListener('message', (e) => {
+                if (e.data.messageId === messageId) {
+                    crystWorker.removeEventListener('message', messageListener);
+                    resolve(e);
+                }
+            })
+            crystWorker.postMessage({
+                messageId, ...kwargs
+            });
+        });
+    }    
+    
+    /**
+     * Appends string to message displayed in log box
+     * @param {string} s - string with the message that will get logged
+     */
     updateLog(s){
         const self = this;
         self.message += s;
         self.setState({log:self.message}, ()=> {self.preRef.current.scrollTop = self.preRef.current.scrollHeight;});
     }
 
-    handleFlip(){
+    
+    /**
+     * Handle the peptide flip and send message with result to crystallography worker
+     */
+     async handleFlip(){
         const self = this;
         let key = self.state.selected;
         const dataObjectNames = this.props.dataObjectsNames;
@@ -42,39 +74,39 @@ class FlipPeptide extends Component {
             key = pdbKeys[0];
         }
         const jobid = guid();
-        const inputData = {method:"flip_peptide",jobId:jobid,pdbinKey:key,chainId:this.state.chainId,resnoFlip:parseInt(this.state.flipRes)};
-        self.props.crystWorker.postMessage(inputData);
+        const inputData = {method:"flip_peptide", jobId:jobid,pdbinKey:key, chainId:this.state.chainId, resnoFlip:parseInt(this.state.flipRes)};
+        let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
     }
 
+    /**
+     * Handle model name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChange(evt){
         this.setState({selected:evt.target.value});
     }
 
+    /**
+     * Handle chain name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChainChange(evt){
         this.setState({chainId:evt.target.value});
     }
 
-    handeleFlipNoChange(evt){
+    /**
+     * Handle residue number change by updating widget state
+     * @param {Event} evt 
+     */
+    handleFlipNoChange(evt){
         this.setState({flipRes:evt.target.value});
     }
 
-    getDataObjectNamesFromSharedArrayBuffer(buffer){
 
-        const view = new Uint8Array(buffer);
-        let buflen = 0;
-        for(let i=0;i<buffer.byteLength;i++){
-            if(view[i] === 0){
-                buflen = i;
-                break;
-            }
-        }
-        const dec = new TextDecoder();
-        const stringified = dec.decode(view.slice(0,buflen));
-        const dataObjectNames = JSON.parse(stringified);
-        return dataObjectNames;
-
-    }
-
+    /**
+     * Renders widget in html format
+     * @returns {string} - html contents with the rendered widget
+     */
     render () {
         const styles = reactCSS({
             'default': {
@@ -137,7 +169,7 @@ class FlipPeptide extends Component {
         <Form.Control required type="text" onChange={this.handleChainChange.bind(this)} placeholder="Chain id" value={this.state.chainId} />
         </Col>
         <Col>
-        <Form.Control required type="number" onChange={this.handeleFlipNoChange.bind(this)} placeholder="Residue" value={this.state.flipRes} />
+        <Form.Control required type="number" onChange={this.handleFlipNoChange.bind(this)} placeholder="Residue" value={this.state.flipRes} />
         </Col>
         </Form.Group>
         </Form>

--- a/react-app/src/FlipPeptide.js
+++ b/react-app/src/FlipPeptide.js
@@ -33,7 +33,6 @@ class FlipPeptide extends Component {
      * @param {Object} kwargs 
      */
     postCrystWorkerMessage(crystWorker, kwargs) {
-        console.log(crystWorker);
         const messageId = guid();
         return new Promise((resolve, reject) => {
             const messageListener = crystWorker.addEventListener('message', (e) => {

--- a/react-app/src/Main.js
+++ b/react-app/src/Main.js
@@ -48,47 +48,47 @@ class Main extends Component {
         this.densityFitRef = React.createRef();
         this.rotamersRef = React.createRef();
         var self = this;
+        
         this.crystWorker.onmessage = function (e) {
-            if (e.data[0] === "dataObjectsNames") {
-                self.setState({dataObjectsNames:e.data[1]});
+            if (e.data.messageTag === "dataObjectsNames") {
+                self.setState({dataObjectsNames:e.data.result});
             }
-            if (e.data[0] === "output") {
-                if (e.data[2] === "mini_rsr") {
-                    self.rsrRef.current.updateLog(e.data[1] + "\n");
-                } else if (e.data[2] === "flip_peptide") {
-                    self.flipRef.current.updateLog(e.data[1] + "\n");
+            if (e.data.messageTag === "output") {
+                if (e.data.taskName === "mini_rsr") {
+                    self.rsrRef.current.updateLog(e.data.result + "\n");
+                } else if (e.data.taskName === "flip_peptide") {
+                    self.flipRef.current.updateLog(e.data.result + "\n");
                 } else {
-                    console.log(e.data[1]);
+                    console.log(e.data.result);
                 }
             }
-            if (e.data[0] === "result" && e.data[2] === "draw_cube") {
-                const theBuffers = self.gl.current.appendOtherData(e.data[1],false,"cube");
+            if (e.data.messageTag === "result" && e.data.taskName === "draw_cube") {
+                const theBuffers = self.gl.current.appendOtherData(e.data.result,false,"cube");
             }
-            if (e.data[0] === "result" && e.data[2] === "get_rama") {
+            if (e.data.messageTag === "result" && e.data.taskName === "get_rama") {
                 self.ramaRef.current.updatePlotData();
             }
-            if (e.data[0] === "result" && e.data[2] === "get_bvals") {
+            if (e.data.messageTag === "result" && e.data.taskName === "get_bvals") {
                 self.bvalRef.current.updatePlotData();
             }
-            if (e.data[0] === "result" && e.data[2] === "density_fit") {
+            if (e.data.messageTag === "result" && e.data.taskName === "density_fit") {
                 self.densityFitRef.current.updatePlotData();
             }
-            if (e.data[0] === "result" && e.data[2] === "rotamers") {
+            if (e.data.messageTag === "result" && e.data.taskName === "rotamers") {
                 self.rotamersRef.current.updatePlotData();
             }
-            if (e.data[0] === "result" && e.data[2] === "get_xyz") {
-                    self.gl.current.setOrigin(e.data[1]);
+            if (e.data.messageTag === "result" && e.data.taskName === "get_xyz") {
+                    self.gl.current.setOrigin(e.data.result);
             }
-            if (e.data[0] === "pdb_out") {
-                const data = e.data[1];
+            if (e.data.messageTag === "pdb_out") {
+                const data = e.data.result;
                 const dataSplit = data.split("\n");
-                const name = e.data[3]+"out";
+                const name = e.data.taskName+"out";
                 const pdbatoms = parsePDB(dataSplit, name);
                 const pending = { fileData: data, atoms: pdbatoms, wizard: "Bonds", name: name };
                 self.filePendingChanged({ pending: pending });
             }
         }
-
     }
 
     componentDidMount() {

--- a/react-app/src/Ramachandran.js
+++ b/react-app/src/Ramachandran.js
@@ -381,7 +381,6 @@ class Ramachandran extends Component {
      * @param {Object} kwargs 
      */
      postCrystWorkerMessage(crystWorker, kwargs) {
-        console.log(crystWorker);
         const messageId = guid();
         return new Promise((resolve, reject) => {
             const messageListener = crystWorker.addEventListener('message', (e) => {

--- a/react-app/src/Ramachandran.js
+++ b/react-app/src/Ramachandran.js
@@ -360,24 +360,11 @@ class Ramachandran extends Component {
         const self = this;
     }
 
-    getDataObjectNamesFromSharedArrayBuffer(buffer){
 
-        const view = new Uint8Array(buffer);
-        let buflen = 0;
-        for(let i=0;i<buffer.byteLength;i++){
-            if(view[i] === 0){
-                buflen = i;
-                break;
-            }
-        }
-        //console.log(buflen);
-        const dec = new TextDecoder();
-        const stringified = dec.decode(view.slice(0,buflen));
-        const dataObjectNames = JSON.parse(stringified);
-        return dataObjectNames;
-
-    }
-
+    /**
+     * Handle model name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChange(evt){
         const self = this;
         this.setState({selected:evt.target.value}, ()=> self.getRama());
@@ -388,7 +375,31 @@ class Ramachandran extends Component {
         evt.preventDefault();
     }
 
-    getRama(){
+    /**
+     * Sends a message to crystallography worker as a promise
+     * @param {Worker} crystWorker 
+     * @param {Object} kwargs 
+     */
+     postCrystWorkerMessage(crystWorker, kwargs) {
+        console.log(crystWorker);
+        const messageId = guid();
+        return new Promise((resolve, reject) => {
+            const messageListener = crystWorker.addEventListener('message', (e) => {
+                if (e.data.messageId === messageId) {
+                    crystWorker.removeEventListener('message', messageListener);
+                    resolve(e);
+                }
+            })
+            crystWorker.postMessage({
+                messageId, ...kwargs
+            });
+        });
+    }    
+
+    /**
+     * Get ramachandran plot and send message with result to crystallography worker
+     */
+    async getRama(){
         const self = this;
         let key = self.state.selected;
         const dataObjectNames = this.props.dataObjectsNames;
@@ -401,11 +412,14 @@ class Ramachandran extends Component {
         }
         const jobid = guid();
         const inputData = {method:"get_rama",jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
-        self.props.crystWorker.postMessage(inputData);
+        let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
         console.log(inputData);
         
     }
 
+    /**
+     * Update contents of ramachandran plot
+     */
     updatePlotData(){
         const self = this;
         let key = self.state.selected;
@@ -422,12 +436,20 @@ class Ramachandran extends Component {
         
     }
 
+    /**
+     * Handle chain name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChainChange(evt){
         const self = this;
         //TODO - calling getRama should be more sane ?
         this.setState({chainId:evt.target.value}, ()=> self.getRama());
     }
 
+    /**
+     * Renders widget in html format
+     * @returns {string} - html contents with the rendered widget
+     */
     render () {
         const styles = reactCSS({
             'default': {

--- a/react-app/src/ResidueData.js
+++ b/react-app/src/ResidueData.js
@@ -301,7 +301,6 @@ class ResidueData extends Component {
      * @param {Object} kwargs 
      */
      postCrystWorkerMessage(crystWorker, kwargs) {
-        console.log(crystWorker);
         const messageId = guid();
         return new Promise((resolve, reject) => {
             const messageListener = crystWorker.addEventListener('message', (e) => {

--- a/react-app/src/ResidueData.js
+++ b/react-app/src/ResidueData.js
@@ -295,6 +295,30 @@ class ResidueData extends Component {
 
     }
 
+    /**
+     * Sends a message to crystallography worker as a promise
+     * @param {Worker} crystWorker 
+     * @param {Object} kwargs 
+     */
+     postCrystWorkerMessage(crystWorker, kwargs) {
+        console.log(crystWorker);
+        const messageId = guid();
+        return new Promise((resolve, reject) => {
+            const messageListener = crystWorker.addEventListener('message', (e) => {
+                if (e.data.messageId === messageId) {
+                    crystWorker.removeEventListener('message', messageListener);
+                    resolve(e);
+                }
+            })
+            crystWorker.postMessage({
+                messageId, ...kwargs
+            });
+        });
+    }    
+
+    /**
+     * Update bfactor plot data
+     */
     updatePlotData(){
         const self = this;
         let key = self.state.selected;
@@ -318,7 +342,10 @@ class ResidueData extends Component {
 
     }
 
-    getData(){
+    /**
+     * Get bfact data and send message with result to crystallography worker
+     */
+    async getData(){
         const self = this;
         let key = self.state.selected;
         const dataObjectNames = this.props.dataObjectsNames;
@@ -331,28 +358,13 @@ class ResidueData extends Component {
         }
         const jobid = guid();
         const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
-        self.props.crystWorker.postMessage(inputData);
-
+        let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
     }
 
-    getDataObjectNamesFromSharedArrayBuffer(buffer){
-
-        const view = new Uint8Array(buffer);
-        let buflen = 0;
-        for(let i=0;i<buffer.byteLength;i++){
-            if(view[i] === 0){
-                buflen = i;
-                break;
-            }
-        }
-        //console.log(buflen);
-        const dec = new TextDecoder();
-        const stringified = dec.decode(view.slice(0,buflen));
-        const dataObjectNames = JSON.parse(stringified);
-        return dataObjectNames;
-
-    }
-
+    /**
+     * Handle model name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChange(evt){
         const self = this;
         this.setState({selected:evt.target.value}, ()=> self.getData());
@@ -362,11 +374,20 @@ class ResidueData extends Component {
         evt.preventDefault();
     }
 
+    /**
+     * Handle chain name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChainChange(evt){
         const self = this;
         this.setState({chainId:evt.target.value}, ()=> self.getData());
     }
 
+
+    /**
+     * Renders widget in html format
+     * @returns {string} - html contents with the rendered widget
+     */
     render () {
         const styles = reactCSS({
             'default': {

--- a/react-app/src/ResidueList.js
+++ b/react-app/src/ResidueList.js
@@ -52,7 +52,6 @@ class ResidueList extends Component {
      * @param {Object} kwargs 
      */
      postCrystWorkerMessage(crystWorker, kwargs) {
-        console.log(crystWorker);
         const messageId = guid();
         return new Promise((resolve, reject) => {
             const messageListener = crystWorker.addEventListener('message', (e) => {

--- a/react-app/src/ResidueList.js
+++ b/react-app/src/ResidueList.js
@@ -46,6 +46,30 @@ class ResidueList extends Component {
 
     }
 
+    /**
+     * Sends a message to crystallography worker as a promise
+     * @param {Worker} crystWorker 
+     * @param {Object} kwargs 
+     */
+     postCrystWorkerMessage(crystWorker, kwargs) {
+        console.log(crystWorker);
+        const messageId = guid();
+        return new Promise((resolve, reject) => {
+            const messageListener = crystWorker.addEventListener('message', (e) => {
+                if (e.data.messageId === messageId) {
+                    crystWorker.removeEventListener('message', messageListener);
+                    resolve(e);
+                }
+            })
+            crystWorker.postMessage({
+                messageId, ...kwargs
+            });
+        });
+    }
+
+    /**
+     * Update rotamer plot data
+     */
     updatePlotData(){
         const self = this;
         let key = self.state.selected;
@@ -65,7 +89,10 @@ class ResidueList extends Component {
 
     }
 
-    getData(){
+    /**
+     * Get rotamers data and send message with result to crystallography worker
+     */
+    async getData(){
         const self = this;
         let key = self.state.selected;
         const dataObjectNames = this.props.dataObjectsNames;
@@ -79,28 +106,13 @@ class ResidueList extends Component {
         const jobid = guid();
 
         const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
-        self.props.crystWorker.postMessage(inputData);
-
+        let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
     }
 
-    getDataObjectNamesFromSharedArrayBuffer(buffer){
-
-        const view = new Uint8Array(buffer);
-        let buflen = 0;
-        for(let i=0;i<buffer.byteLength;i++){
-            if(view[i] === 0){
-                buflen = i;
-                break;
-            }
-        }
-        //console.log(buflen);
-        const dec = new TextDecoder();
-        const stringified = dec.decode(view.slice(0,buflen));
-        const dataObjectNames = JSON.parse(stringified);
-        return dataObjectNames;
-
-    }
-
+    /**
+     * Handle model name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChange(evt){
         const self = this;
         this.setState({selected:evt.target.value}, ()=> self.getData());
@@ -110,11 +122,19 @@ class ResidueList extends Component {
         evt.preventDefault();
     }
 
+    /**
+     * Handle chain name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChainChange(evt){
         const self = this;
         this.setState({chainId:evt.target.value}, ()=> self.getData());
     }
 
+    /**
+     * Renders widget in html format
+     * @returns {string} - html contents with the rendered widget
+     */
     render () {
         const styles = reactCSS({
             'default': {

--- a/react-app/src/ResidueMapData.js
+++ b/react-app/src/ResidueMapData.js
@@ -295,7 +295,31 @@ class ResidueMapData extends Component {
         this.clickHandler = this.props.clickHandler;
 
     }
+    
+    /**
+     * Sends a message to crystallography worker as a promise
+     * @param {Worker} crystWorker 
+     * @param {Object} kwargs 
+     */
+     postCrystWorkerMessage(crystWorker, kwargs) {
+        console.log(crystWorker);
+        const messageId = guid();
+        return new Promise((resolve, reject) => {
+            const messageListener = crystWorker.addEventListener('message', (e) => {
+                if (e.data.messageId === messageId) {
+                    crystWorker.removeEventListener('message', messageListener);
+                    resolve(e);
+                }
+            })
+            crystWorker.postMessage({
+                messageId, ...kwargs
+            });
+        });
+    }    
 
+    /**
+     * Update density fit plot data
+     */
     updatePlotData(){
         const self = this;
         let key = self.state.selected;
@@ -318,8 +342,11 @@ class ResidueMapData extends Component {
         }
 
     }
-
-    getData(){
+    
+    /**
+     * Get density fit data and send message with result to crystallography worker
+     */
+    async getData(){
         const self = this;
         let key = self.state.selected;
         let keyMap = self.state.mapSelected;
@@ -337,33 +364,23 @@ class ResidueMapData extends Component {
         }
         const jobid = guid();
         const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,hklinKey:keyMap,chainId:this.state.chainId};
-        self.props.crystWorker.postMessage(inputData);
+        let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
 
     }
 
-    getDataObjectNamesFromSharedArrayBuffer(buffer){
-
-        const view = new Uint8Array(buffer);
-        let buflen = 0;
-        for(let i=0;i<buffer.byteLength;i++){
-            if(view[i] === 0){
-                buflen = i;
-                break;
-            }
-        }
-        //console.log(buflen);
-        const dec = new TextDecoder();
-        const stringified = dec.decode(view.slice(0,buflen));
-        const dataObjectNames = JSON.parse(stringified);
-        return dataObjectNames;
-
-    }
-
+    /**
+     * Handle model name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChange(evt){
         const self = this;
         this.setState({selected:evt.target.value}, ()=> self.getData());
     }
 
+    /**
+     * Handle map name change by updating widget state
+     * @param {Event} evt 
+     */
     handleMapChange(evt){
         const self = this;
         this.setState({mapSelected:evt.target.value}, ()=> self.getData());
@@ -373,11 +390,19 @@ class ResidueMapData extends Component {
         evt.preventDefault();
     }
 
+    /**
+     * Handle chain name change by updating widget state
+     * @param {Event} evt 
+     */
     handleChainChange(evt){
         const self = this;
         this.setState({chainId:evt.target.value}, ()=> self.getData());
     }
 
+    /**
+     * Renders widget in html format
+     * @returns {string} - html contents with the rendered widget
+     */
     render () {
         const styles = reactCSS({
             'default': {

--- a/react-app/src/ResidueMapData.js
+++ b/react-app/src/ResidueMapData.js
@@ -302,7 +302,6 @@ class ResidueMapData extends Component {
      * @param {Object} kwargs 
      */
      postCrystWorkerMessage(crystWorker, kwargs) {
-        console.log(crystWorker);
         const messageId = guid();
         return new Promise((resolve, reject) => {
             const messageListener = crystWorker.addEventListener('message', (e) => {

--- a/web_example/crystallography_worker.js
+++ b/web_example/crystallography_worker.js
@@ -5,7 +5,11 @@
 
 let currentTaskName = "";
 function rsrPrint(t){
-    postMessage(["output",t,currentTaskName]);
+    postMessage({
+        messageTag: "output",
+        result: t,
+        taskName: currentTaskName
+    })
 }
 
 let CCP4Module;
@@ -69,8 +73,11 @@ function guid(){
 // * Change dataObjectsNames to globalCache or something
 // * Add Rama data to the globalCache
 
-function updateShareArrayBuffer(){
-    postMessage(["dataObjectsNames",dataObjectsNames]);
+function updateDataObjectsNames(){
+    postMessage({
+        messageTag: "dataObjectsNames",
+        result: dataObjectsNames,
+    })
 }
 
 function downLoadFiles(files){
@@ -167,7 +174,7 @@ function loadFiles(files){
             const result = molecules_container.read_pdb(key + ".pdb");
             dataObjectsNames.mol_cont_idx[key] = result;
         }
-        updateShareArrayBuffer();
+        updateDataObjectsNames();
     }) .catch(function(err) {
         console.log(err);
     });
@@ -194,7 +201,7 @@ function loadFiles(files){
             const result = molecules_container.read_mtz(key + ".mtz",f,phi,wt,use_wt,is_diff);
             dataObjectsNames.map_cont_idx[key] = result;
         }
-        updateShareArrayBuffer();
+        updateDataObjectsNames();
     }).catch(function(err) {
         console.log(err);
     });
@@ -230,8 +237,13 @@ function getDensityFit(e) {
         resInfoJS.push(jsres);
     }
     dataObjectsNames.densityFitInfo[e.data.pdbinKey] = resInfoJS;
-    updateShareArrayBuffer();
-    postMessage(["result",result,currentTaskName]);
+    updateDataObjectsNames();
+        postMessage({
+        messageId: e.data.messageId,
+        messageTag: "result",
+        result: result,
+        taskName: currentTaskName
+    })
 }
 
 function getBVals(e) {
@@ -248,8 +260,13 @@ function getBVals(e) {
         resInfo.push(jsres);
     }
     dataObjectsNames.bvalInfo[e.data.pdbinKey] = resInfo;
-    updateShareArrayBuffer();
-    postMessage(["result",result,currentTaskName]);
+    updateDataObjectsNames();
+    postMessage({
+        messageId: e.data.messageId,
+        messageTag: "result",
+        result: result,
+        taskName: currentTaskName
+    })
 }
 
 function getRama(e) {
@@ -267,8 +284,13 @@ function getRama(e) {
         resInfo.push(jsres);
     }
     dataObjectsNames.ramaInfo[e.data.pdbinKey] = resInfo;
-    updateShareArrayBuffer();
-    postMessage(["result",result,currentTaskName]);
+    updateDataObjectsNames();
+    postMessage({
+        messageId: e.data.messageId,
+        messageTag: "result",
+        result: result,
+        taskName: currentTaskName
+    })
 }
 
 function drawCube(e) {
@@ -300,8 +322,12 @@ function drawCube(e) {
     }
     const cubeInfo = {prim_types:[["TRIANGLES"]],idx_tri:[[totIdxs]],vert_tri:[[totPos]],norm_tri:[[totNorm]],col_tri:[[totCol]]};
     console.log(cubeInfo);
-    postMessage(["result",cubeInfo,currentTaskName]);
-
+    postMessage({
+        messageId: e.data.messageId,
+        messageTag: "result",
+        result: cubeInfo,
+        taskName: currentTaskName
+    })
 }
 
 function getRotamers(e) {
@@ -334,8 +360,13 @@ function getRotamers(e) {
     }
 
     dataObjectsNames.rotamersInfo[e.data.pdbinKey] = rotamersInfo;
-    updateShareArrayBuffer();
-    postMessage(["result",0,currentTaskName]);
+    updateDataObjectsNames();
+    postMessage({
+        messageId: e.data.messageId,
+        messageTag: "result",
+        result: 0,
+        taskName: currentTaskName
+    })
 }
 
 function flipPeptide(e) {
@@ -361,8 +392,19 @@ function flipPeptide(e) {
     var pdb_out = RSRModule.FS.readFile(pdbout, { encoding: 'utf8' });
 
     //postMessage(["result",result,currentTaskName]);
-    postMessage(["result",resultMolCont,currentTaskName]);
-    postMessage(["pdb_out",pdb_out,jobId,currentTaskName]);
+    postMessage({
+        messageId: e.data.messageId,
+        messageTag: "result",
+        result: resultMolCont,
+        taskName: currentTaskName
+    })
+    postMessage({
+        messageId: e.data.messageId,
+        messageTag: "pdb_out",
+        jobId: jobId,
+        result: pdb_out,
+        taskName: currentTaskName
+    })
 }
 
 function miniRSR(e) {
@@ -399,10 +441,19 @@ function miniRSR(e) {
     var result = RSRModule.mini_rsr(args);
     var pdb_out = RSRModule.FS.readFile(jobId+"out.pdb", { encoding: 'utf8' });
     //TODO We need to store pdb_out! (and cache with updateShareArrayBuffer)
-
-    postMessage(["result",result,currentTaskName]);
-    postMessage(["pdb_out",pdb_out,jobId,currentTaskName]);
-}
+    postMessage({
+        messageId: e.data.messageId,
+        messageTag: "result",
+        result: result,
+        taskName: currentTaskName
+    })
+    postMessage({
+        messageId: e.data.messageId,
+        messageTag: "pdb_out",
+        jobId: jobId,
+        result: pdb_out,
+        taskName: currentTaskName
+    })}
 
 
 onmessage = function(e) {
@@ -471,7 +522,12 @@ onmessage = function(e) {
                     result = CCP4Module.getXYZResNo(dataObjects.pdbFiles[theData_id].fileName,e.data.resInfo.chain,e.data.resInfo.resNo);
                 }
                 if(result.size()===3){
-                    postMessage(["result",[-result.get(0),-result.get(1),-result.get(2)],currentTaskName]);
+                    postMessage({
+                        messageId: e.data.messageId,
+                        messageTag: "result",
+                        result: [-result.get(0),-result.get(1),-result.get(2)],
+                        taskName: currentTaskName
+                    })
                 }
             }
             currentTaskName = "";


### PR DESCRIPTION
This update closes #3 
It includes the following changes:
- Removed last traces of `sharedArrayBuffer`.
- Using JSDoc markup language to start documenting functions. I know in some cases the usage of the function is quite obvious but I think it would be good to start using this to document code.
- Widgets now post messages to crystallographby worker via promises.
- Widgets post messages consisting of objects rather than arrays. I feel this will keep the code more tidy as it will be very easy to refactor code in the future to add more attributes to these messages in future updates rather than having to keep track of array indices. What do you think?
- Using `async...await` syntax to deal with promises.