### PR TITLE
Pass results from crystWorker straigth into widgets

### DIFF
--- a/react-app/src/Main.js
+++ b/react-app/src/Main.js
@@ -65,18 +65,6 @@ class Main extends Component {
             if (e.data.messageTag === "result" && e.data.taskName === "draw_cube") {
                 const theBuffers = self.gl.current.appendOtherData(e.data.result,false,"cube");
             }
-            if (e.data.messageTag === "result" && e.data.taskName === "get_rama") {
-                self.ramaRef.current.updatePlotData();
-            }
-            if (e.data.messageTag === "result" && e.data.taskName === "get_bvals") {
-                self.bvalRef.current.updatePlotData();
-            }
-            if (e.data.messageTag === "result" && e.data.taskName === "density_fit") {
-                self.densityFitRef.current.updatePlotData();
-            }
-            if (e.data.messageTag === "result" && e.data.taskName === "rotamers") {
-                self.rotamersRef.current.updatePlotData();
-            }
             if (e.data.messageTag === "result" && e.data.taskName === "get_xyz") {
                     self.gl.current.setOrigin(e.data.result);
             }

--- a/react-app/src/Ramachandran.js
+++ b/react-app/src/Ramachandran.js
@@ -422,7 +422,7 @@ class Ramachandran extends Component {
      */
     updatePlotData(plotData, key){
         const self = this;
-        self.ramaRef.current.updatePlotData({info:plotData, key:plotData.key});
+        self.ramaRef.current.updatePlotData({info:plotData, key:key});
         this.setState({plotInfo:plotData});
     }
 

--- a/react-app/src/Ramachandran.js
+++ b/react-app/src/Ramachandran.js
@@ -355,7 +355,7 @@ class Ramachandran extends Component {
 
         this.ramaRef = createRef();
 
-        this.state = {selected:"unk",log:"", chainId:"", plotInfo: null};
+        this.state = {selected:"unk", log:"", chainId:"", plotInfo: null, key:null};
         this.message = "";
         const self = this;
     }
@@ -381,6 +381,7 @@ class Ramachandran extends Component {
      * @param {Object} kwargs 
      */
      postCrystWorkerMessage(crystWorker, kwargs) {
+        console.log(crystWorker);
         const messageId = guid();
         return new Promise((resolve, reject) => {
             const messageListener = crystWorker.addEventListener('message', (e) => {
@@ -412,26 +413,18 @@ class Ramachandran extends Component {
         const jobid = guid();
         const inputData = {method:"get_rama",jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
         let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
-        this.updatePlotData(response.data.result);
+        this.updatePlotData(response.data.result, key);
    }
 
     /**
      * Update contents of ramachandran plot
+     * @param {array} plotData - array with residue information
+     * @param {string} key - key for the selected pdb model
      */
-    updatePlotData(plotData){
+    updatePlotData(plotData, key){
         const self = this;
-        let key = self.state.selected;
-        const dataObjectNames = this.props.dataObjectsNames;
-        const pdbKeys = Object.keys(dataObjectNames.pdbFiles);
-        if(pdbKeys.length<1){
-            return;
-        }
-        if(key==="unk"){
-            key = pdbKeys[0];
-        }
-        self.ramaRef.current.updatePlotData({info:plotData, key:key});
-        this.setState({plotInfo:plotData});
-        
+        self.ramaRef.current.updatePlotData({info:plotData, key:plotData.key});
+        this.setState({plotInfo:plotData, key:plotData.key});
     }
 
     /**

--- a/react-app/src/Ramachandran.js
+++ b/react-app/src/Ramachandran.js
@@ -381,7 +381,6 @@ class Ramachandran extends Component {
      * @param {Object} kwargs 
      */
      postCrystWorkerMessage(crystWorker, kwargs) {
-        console.log(crystWorker);
         const messageId = guid();
         return new Promise((resolve, reject) => {
             const messageListener = crystWorker.addEventListener('message', (e) => {

--- a/react-app/src/Ramachandran.js
+++ b/react-app/src/Ramachandran.js
@@ -355,7 +355,7 @@ class Ramachandran extends Component {
 
         this.ramaRef = createRef();
 
-        this.state = {selected:"unk", log:"", chainId:"", plotInfo: null, key:null};
+        this.state = {selected:"unk",log:"", chainId:"", plotInfo: null};
         this.message = "";
         const self = this;
     }
@@ -423,7 +423,7 @@ class Ramachandran extends Component {
     updatePlotData(plotData, key){
         const self = this;
         self.ramaRef.current.updatePlotData({info:plotData, key:plotData.key});
-        this.setState({plotInfo:plotData, key:plotData.key});
+        this.setState({plotInfo:plotData});
     }
 
     /**

--- a/react-app/src/Ramachandran.js
+++ b/react-app/src/Ramachandran.js
@@ -343,7 +343,7 @@ class RamaPlot extends Component {
 
     updatePlotData(plotInfo){
         const self = this;
-        this.setState({plotInfo:plotInfo.info,key:plotInfo.key},()=>self.draw());
+        this.setState({plotInfo:plotInfo.info, key:plotInfo.key},()=>self.draw());
     }
     
 }
@@ -381,6 +381,7 @@ class Ramachandran extends Component {
      * @param {Object} kwargs 
      */
      postCrystWorkerMessage(crystWorker, kwargs) {
+        console.log(crystWorker);
         const messageId = guid();
         return new Promise((resolve, reject) => {
             const messageListener = crystWorker.addEventListener('message', (e) => {
@@ -412,14 +413,13 @@ class Ramachandran extends Component {
         const jobid = guid();
         const inputData = {method:"get_rama",jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
         let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
-        console.log(inputData);
-        
-    }
+        this.updatePlotData(response.data.result);
+   }
 
     /**
      * Update contents of ramachandran plot
      */
-    updatePlotData(){
+    updatePlotData(plotData){
         const self = this;
         let key = self.state.selected;
         const dataObjectNames = this.props.dataObjectsNames;
@@ -430,8 +430,8 @@ class Ramachandran extends Component {
         if(key==="unk"){
             key = pdbKeys[0];
         }
-        self.ramaRef.current.updatePlotData({info:dataObjectNames.ramaInfo[key],key:key});
-        this.setState({plotInfo:dataObjectNames.ramaInfo[key]});
+        self.ramaRef.current.updatePlotData({info:plotData, key:key});
+        this.setState({plotInfo:plotData});
         
     }
 

--- a/react-app/src/ResidueData.js
+++ b/react-app/src/ResidueData.js
@@ -318,7 +318,7 @@ class ResidueData extends Component {
     /**
      * Update bfactor plot data
      */
-    updatePlotData(){
+    updatePlotData(plotData){
         const self = this;
         let key = self.state.selected;
         const dataObjectNames = this.props.dataObjectsNames;
@@ -335,10 +335,9 @@ class ResidueData extends Component {
         self.plotRef.current.customClickHandler = this.clickHandler;
 
         if(dataObjectNames[self.infoName] && dataObjectNames[self.infoName][key]){
-            self.plotRef.current.updatePlotData({info:dataObjectNames[self.infoName][key],key:key});
-            this.setState({plotInfo:dataObjectNames[self.infoName][key]});
+            self.plotRef.current.updatePlotData({info:plotData, key:key});
+            this.setState({plotInfo:plotData});
         }
-
     }
 
     /**
@@ -358,6 +357,7 @@ class ResidueData extends Component {
         const jobid = guid();
         const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
         let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
+        this.updatePlotData(response.data.result);
     }
 
     /**

--- a/react-app/src/ResidueData.js
+++ b/react-app/src/ResidueData.js
@@ -316,25 +316,18 @@ class ResidueData extends Component {
     }    
 
     /**
-     * Update bfactor plot data
+     * Update contents of plot
+     * @param {array} plotData - array with residue information
+     * @param {string} key - key for the selected pdb model
      */
-    updatePlotData(plotData){
+     updatePlotData(plotData, key){
         const self = this;
-        let key = self.state.selected;
-        const dataObjectNames = this.props.dataObjectsNames;
-        const pdbKeys = Object.keys(dataObjectNames.pdbFiles);
-        if(pdbKeys.length<1){
-            return;
-        }
-        if(key==="unk"){
-            key = pdbKeys[0];
-        }
-
+ 
         self.plotRef.current.dataKey = this.dataKey;
         self.plotRef.current.dataInfoScaling = this.dataInfoScaling;
         self.plotRef.current.customClickHandler = this.clickHandler;
 
-        if(dataObjectNames[self.infoName] && dataObjectNames[self.infoName][key]){
+        if(plotData){
             self.plotRef.current.updatePlotData({info:plotData, key:key});
             this.setState({plotInfo:plotData});
         }
@@ -357,7 +350,7 @@ class ResidueData extends Component {
         const jobid = guid();
         const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
         let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
-        this.updatePlotData(response.data.result);
+        this.updatePlotData(response.data.result, key);
     }
 
     /**

--- a/react-app/src/ResidueList.js
+++ b/react-app/src/ResidueList.js
@@ -84,9 +84,7 @@ class ResidueList extends Component {
 
         const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
         let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
-        console.log(response.data.result);
         if(response.data.result){
-            console.log('UPDATE');
             this.setState({plotInfo:response.data.result});
         }
         
@@ -189,9 +187,6 @@ class ResidueList extends Component {
                 }
             }
         }
-        console.log('RENDER');
-        console.log(buttons);
-        console.log(this.state.plotInfo);
 
         //TODO - Need to introspect the pdb file to see what chains exist and pick the first one ...
 

--- a/react-app/src/ResidueList.js
+++ b/react-app/src/ResidueList.js
@@ -69,7 +69,7 @@ class ResidueList extends Component {
     /**
      * Update rotamer plot data
      */
-    updatePlotData(){
+    updatePlotData(plotData){
         const self = this;
         let key = self.state.selected;
         const dataObjectNames = this.props.dataObjectsNames;
@@ -83,7 +83,7 @@ class ResidueList extends Component {
 
 
         if(dataObjectNames[self.infoName] && dataObjectNames[self.infoName][key]){
-            this.setState({plotInfo:dataObjectNames[self.infoName][key]});
+            this.setState({plotInfo:plotData});
         }
 
     }
@@ -106,6 +106,7 @@ class ResidueList extends Component {
 
         const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
         let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
+        this.updatePlotData(response.data.result);
     }
 
     /**

--- a/react-app/src/ResidueList.js
+++ b/react-app/src/ResidueList.js
@@ -67,28 +67,6 @@ class ResidueList extends Component {
     }
 
     /**
-     * Update rotamer plot data
-     */
-    updatePlotData(plotData){
-        const self = this;
-        let key = self.state.selected;
-        const dataObjectNames = this.props.dataObjectsNames;
-        const pdbKeys = Object.keys(dataObjectNames.pdbFiles);
-        if(pdbKeys.length<1){
-            return;
-        }
-        if(key==="unk"){
-            key = pdbKeys[0];
-        }
-
-
-        if(dataObjectNames[self.infoName] && dataObjectNames[self.infoName][key]){
-            this.setState({plotInfo:plotData});
-        }
-
-    }
-
-    /**
      * Get rotamers data and send message with result to crystallography worker
      */
     async getData(){
@@ -106,7 +84,12 @@ class ResidueList extends Component {
 
         const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,chainId:this.state.chainId};
         let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
-        this.updatePlotData(response.data.result);
+        console.log(response.data.result);
+        if(response.data.result){
+            console.log('UPDATE');
+            this.setState({plotInfo:response.data.result});
+        }
+        
     }
 
     /**
@@ -187,9 +170,9 @@ class ResidueList extends Component {
         }
 
         let buttons = [];
-        if(dataObjectNames[self.infoName][selected]){
-            for(let i=0;i<dataObjectNames[self.infoName][selected].length;i++){
-                const resData = dataObjectNames[self.infoName][selected][i];
+        if(this.state.plotInfo){
+            for(let i=0;i<this.state.plotInfo.length;i++){
+                const resData = this.state.plotInfo[i];
                 if(resData.data&&resData.data.length>0){
                     const buttonId = "reslistbutton-"+i;
                     let buttonLabel;
@@ -206,6 +189,9 @@ class ResidueList extends Component {
                 }
             }
         }
+        console.log('RENDER');
+        console.log(buttons);
+        console.log(this.state.plotInfo);
 
         //TODO - Need to introspect the pdb file to see what chains exist and pick the first one ...
 

--- a/react-app/src/ResidueMapData.js
+++ b/react-app/src/ResidueMapData.js
@@ -317,25 +317,18 @@ class ResidueMapData extends Component {
     }    
 
     /**
-     * Update density fit plot data
+     * Update contents of plot
+     * @param {array} plotData - array with residue information
+     * @param {string} key - key for the selected pdb model
      */
-    updatePlotData(plotData){
+     updatePlotData(plotData, key){
         const self = this;
-        let key = self.state.selected;
-        const dataObjectNames = this.props.dataObjectsNames;
-        const pdbKeys = Object.keys(dataObjectNames.pdbFiles);
-        if(pdbKeys.length<1){
-            return;
-        }
-        if(key==="unk"){
-            key = pdbKeys[0];
-        }
 
         self.plotRef.current.dataKey = this.dataKey;
         self.plotRef.current.dataInfoScaling = this.dataInfoScaling;
         self.plotRef.current.customClickHandler = this.clickHandler;
 
-        if(dataObjectNames[self.infoName] && dataObjectNames[self.infoName][key]){
+        if(plotData){
             self.plotRef.current.updatePlotData({info:plotData, key:key});
             this.setState({plotInfo:plotData});
         }
@@ -347,7 +340,7 @@ class ResidueMapData extends Component {
      */
     async getData(){
         const self = this;
-        let key = self.state.selected;
+        let keyModel = self.state.selected;
         let keyMap = self.state.mapSelected;
         const dataObjectNames = this.props.dataObjectsNames;
         const pdbKeys = Object.keys(dataObjectNames.pdbFiles);
@@ -355,16 +348,16 @@ class ResidueMapData extends Component {
         if(pdbKeys.length<1){
             return;
         }
-        if(key==="unk"){
-            key = pdbKeys[0];
+        if(keyModel==="unk"){
+            keyModel = pdbKeys[0];
         }
         if(keyMap==="unk"){
             keyMap = mtzKeys[0];
         }
         const jobid = guid();
-        const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,hklinKey:keyMap,chainId:this.state.chainId};
+        const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:keyModel,hklinKey:keyMap,chainId:this.state.chainId};
         let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
-        this.updatePlotData(response.data.result);
+        this.updatePlotData(response.data.result, keyModel);
 
     }
 

--- a/react-app/src/ResidueMapData.js
+++ b/react-app/src/ResidueMapData.js
@@ -319,7 +319,7 @@ class ResidueMapData extends Component {
     /**
      * Update density fit plot data
      */
-    updatePlotData(){
+    updatePlotData(plotData){
         const self = this;
         let key = self.state.selected;
         const dataObjectNames = this.props.dataObjectsNames;
@@ -336,8 +336,8 @@ class ResidueMapData extends Component {
         self.plotRef.current.customClickHandler = this.clickHandler;
 
         if(dataObjectNames[self.infoName] && dataObjectNames[self.infoName][key]){
-            self.plotRef.current.updatePlotData({info:dataObjectNames[self.infoName][key],key:key});
-            this.setState({plotInfo:dataObjectNames[self.infoName][key]});
+            self.plotRef.current.updatePlotData({info:plotData, key:key});
+            this.setState({plotInfo:plotData});
         }
 
     }
@@ -364,6 +364,7 @@ class ResidueMapData extends Component {
         const jobid = guid();
         const inputData = {method:self.crystMethod,jobId:jobid,pdbinKey:key,hklinKey:keyMap,chainId:this.state.chainId};
         let response = await this.postCrystWorkerMessage(self.props.crystWorker, inputData);
+        this.updatePlotData(response.data.result);
 
     }
 

--- a/web_example/crystallography_worker.js
+++ b/web_example/crystallography_worker.js
@@ -236,8 +236,6 @@ function getDensityFit(e) {
         const jsres = {chainId:CPPchainId,insCode:insCode,seqNum:seqNum,restype:restype,density_fit:1./value};
         resInfoJS.push(jsres);
     }
-    dataObjectsNames.densityFitInfo[e.data.pdbinKey] = resInfoJS;
-    updateDataObjectsNames();
     postMessage({
         messageId: e.data.messageId,
         messageTag: "result",
@@ -259,8 +257,6 @@ function getBVals(e) {
         const jsres = {chainId:cppres.chainId,insCode:cppres.insCode,seqNum:cppres.seqNum,restype:cppres.restype,bval:cppres.property};
         resInfo.push(jsres);
     }
-    dataObjectsNames.bvalInfo[e.data.pdbinKey] = resInfo;
-    updateDataObjectsNames();
     postMessage({
         messageId: e.data.messageId,
         messageTag: "result",
@@ -283,8 +279,6 @@ function getRama(e) {
         const jsres = {chainId:cppres.chainId,insCode:cppres.insCode,seqNum:cppres.seqNum,restype:cppres.restype,phi:cppres.phi,psi:cppres.psi,isOutlier:cppres.isOutlier,is_pre_pro:cppres.is_pre_pro};
         resInfo.push(jsres);
     }
-    dataObjectsNames.ramaInfo[e.data.pdbinKey] = resInfo;
-    updateDataObjectsNames();
     postMessage({
         messageId: e.data.messageId,
         messageTag: "result",
@@ -366,13 +360,10 @@ function getRotamers(e) {
             rotamersInfo.push({chainId:chainId,seqNum:residueSpecList.get(i).res_no,insCode:residueSpecList.get(i).ins_code,restype:residueList.get(i),data:[]});
         }
     }
-
-    dataObjectsNames.rotamersInfo[e.data.pdbinKey] = rotamersInfo;
-    updateDataObjectsNames();
     postMessage({
         messageId: e.data.messageId,
         messageTag: "result",
-        result: 0,
+        result: rotamersInfo,
         taskName: currentTaskName
     })
 }

--- a/web_example/crystallography_worker.js
+++ b/web_example/crystallography_worker.js
@@ -238,10 +238,10 @@ function getDensityFit(e) {
     }
     dataObjectsNames.densityFitInfo[e.data.pdbinKey] = resInfoJS;
     updateDataObjectsNames();
-        postMessage({
+    postMessage({
         messageId: e.data.messageId,
         messageTag: "result",
-        result: result,
+        result: resInfoJS,
         taskName: currentTaskName
     })
 }
@@ -264,7 +264,7 @@ function getBVals(e) {
     postMessage({
         messageId: e.data.messageId,
         messageTag: "result",
-        result: result,
+        result: resInfo,
         taskName: currentTaskName
     })
 }
@@ -288,7 +288,7 @@ function getRama(e) {
     postMessage({
         messageId: e.data.messageId,
         messageTag: "result",
-        result: result,
+        result: resInfo,
         taskName: currentTaskName
     })
 }


### PR DESCRIPTION
This avoids using `Main.js` to update the plots. I think we cannot get totally get rid of `dataObjectNames` as the widgets use it to get the `pdbKey` and `mapKey` of the selected model and map. It also gets used in the `render()` method. Not sure if this update is exactly what you had in mind?