### PR TITLE
Refactor ramaplot and seqViewer to use the same methd to centre on residues

### DIFF
--- a/baby-gru/src/components/BabyGruMolecule.js
+++ b/baby-gru/src/components/BabyGruMolecule.js
@@ -126,13 +126,34 @@ BabyGruMolecule.prototype.centreOn = function (gl, selection) {
     else {
         promise = Promise.resolve()
     }
+
+    let selectionCentre = null;
+    if (selection) {
+        let selectedChainIndex = $this.cachedAtoms.atoms[selection.modelIndex].chains.findIndex(chain => chain.residues[0].atoms[0]["_atom_site.auth_asym_id"] === selection.chain);
+        if (selectedChainIndex === -1) {
+            console.log(`Cannot find chain ${selection.molName}/${selection.chain}`)
+            return
+        }
+        let selectedResidueIndex = $this.cachedAtoms.atoms[selection.modelIndex].chains[selectedChainIndex].residues.findIndex(residue => residue.atoms[0]["_atom_site.label_seq_id"] == selection.seqNum);
+        if (selectedResidueIndex === -1) {
+            console.log(`Cannot find residue ${selection.molName}/${selection.chain}/${selection.seqNum}`)
+        } else {
+            let selectedAtoms = $this.cachedAtoms.atoms[selection.modelIndex].chains[selectedChainIndex].residues[selectedResidueIndex].atoms;
+            selectionCentre = $this.cachedAtoms.atoms[selection.modelIndex].centreOnAtoms(selectedAtoms)
+
+        }
+    } else {
+        selectionCentre = $this.cachedAtoms.atoms[0].centre()
+    }
+
     return promise.then(() => {
         return new Promise((resolve, reject) => {
-            gl.current.setOrigin($this.cachedAtoms.atoms[0].centre())
+            gl.current.setOrigin(selectionCentre)
             resolve(true)
         })
     })
 }
+
 
 BabyGruMolecule.prototype.drawWithStyleFromAtoms = function (style, gl, webMGAtoms) {
 

--- a/baby-gru/src/components/BabyGruMolecule.js
+++ b/baby-gru/src/components/BabyGruMolecule.js
@@ -131,25 +131,25 @@ BabyGruMolecule.prototype.centreOn = function (gl, selection) {
     if (selection) {
         let selectedChainIndex = $this.cachedAtoms.atoms[selection.modelIndex].chains.findIndex(chain => chain.residues[0].atoms[0]["_atom_site.auth_asym_id"] === selection.chain);
         if (selectedChainIndex === -1) {
-            console.log(`Cannot find chain ${selection.molName}/${selection.chain}`)
-            return
+            console.log(`Cannot find chain ${selection.molName}/${selection.chain}`);
+            return;
         }
         let selectedResidueIndex = $this.cachedAtoms.atoms[selection.modelIndex].chains[selectedChainIndex].residues.findIndex(residue => residue.atoms[0]["_atom_site.label_seq_id"] == selection.seqNum);
         if (selectedResidueIndex === -1) {
-            console.log(`Cannot find residue ${selection.molName}/${selection.chain}/${selection.seqNum}`)
+            console.log(`Cannot find residue ${selection.molName}/${selection.chain}/${selection.seqNum}`);
+            return;
         } else {
             let selectedAtoms = $this.cachedAtoms.atoms[selection.modelIndex].chains[selectedChainIndex].residues[selectedResidueIndex].atoms;
-            selectionCentre = $this.cachedAtoms.atoms[selection.modelIndex].centreOnAtoms(selectedAtoms)
-
+            selectionCentre = $this.cachedAtoms.atoms[selection.modelIndex].centreOnAtoms(selectedAtoms);
         }
     } else {
-        selectionCentre = $this.cachedAtoms.atoms[0].centre()
+        selectionCentre = $this.cachedAtoms.atoms[0].centre();
     }
 
     return promise.then(() => {
         return new Promise((resolve, reject) => {
-            gl.current.setOrigin(selectionCentre)
-            resolve(true)
+            gl.current.setOrigin(selectionCentre);
+            resolve(true);
         })
     })
 }

--- a/baby-gru/src/components/BabyGruRamachandran.js
+++ b/baby-gru/src/components/BabyGruRamachandran.js
@@ -23,7 +23,6 @@ export const BabyGruRamachandran = (props) => {
     }, [inspect(props.molecules[moleculeIndex])])
 
 
-    // TODO: REFACTOR THIS CODE, IT IS THE SAME AS IN THE SEQUENCE VIEWER...
     useEffect(() => {
         if (!clickedResidue) {
             return
@@ -35,21 +34,8 @@ export const BabyGruRamachandran = (props) => {
             return
         }
 
-        // WARNING: Currently we assume that selected model is always the first one...
-        let selectedModelIndex = 0
-        let selectedChainIndex = props.molecules[selectedMoleculeIndex].cachedAtoms.atoms[selectedModelIndex].chains.findIndex(chain => chain.residues[0].atoms[0]["_atom_site.auth_asym_id"] === clickedResidue.chain);
-        if (selectedChainIndex === -1) {
-            console.log(`Cannot find chain ${clickedResidue.molName}/${clickedResidue.chain}`)
-            return
-        }
+        props.molecules[selectedMoleculeIndex].centreOn(props.glRef, clickedResidue)
 
-        let selectedResidueIndex = props.molecules[selectedMoleculeIndex].cachedAtoms.atoms[selectedModelIndex].chains[selectedChainIndex].residues.findIndex(residue => residue.atoms[0]["_atom_site.label_seq_id"] == clickedResidue.seqNum);
-        if (selectedResidueIndex === -1) {
-            console.log(`Cannot find residue ${clickedResidue.molName}/${clickedResidue.chain}/${clickedResidue.seqNum}`)
-        } else {
-            let selectedResidueAtoms = props.molecules[selectedMoleculeIndex].cachedAtoms.atoms[selectedModelIndex].chains[selectedChainIndex].residues[selectedResidueIndex].atoms;
-            props.glRef.current.setOrigin(props.molecules[selectedMoleculeIndex].cachedAtoms.atoms[selectedModelIndex].centreOnAtoms(selectedResidueAtoms))
-        }
     }, [clickedResidue])
 
 

--- a/baby-gru/src/components/BabyGruSequenceViewer.js
+++ b/baby-gru/src/components/BabyGruSequenceViewer.js
@@ -35,21 +35,8 @@ export const BabyGruSequenceViewer = (props) => {
             return
         }
 
-        // WARNING: Currently we assume that selected model is always the first one...
-        let selectedModelIndex = 0
-        let selectedChainIndex = props.molecules[selectedMoleculeIndex].cachedAtoms.atoms[selectedModelIndex].chains.findIndex(chain => chain.residues[0].atoms[0]["_atom_site.auth_asym_id"] === clickedResidue.chain);
-        if (selectedChainIndex === -1) {
-            console.log(`Cannot find chain ${clickedResidue.molName}/${clickedResidue.chain}`)
-            return
-        }
+        props.molecules[selectedMoleculeIndex].centreOn(props.glRef, clickedResidue)
 
-        let selectedResidueIndex = props.molecules[selectedMoleculeIndex].cachedAtoms.atoms[selectedModelIndex].chains[selectedChainIndex].residues.findIndex(residue => residue.atoms[0]["_atom_site.label_seq_id"] == clickedResidue.seqNum);
-        if (selectedResidueIndex === -1) {
-            console.log(`Cannot find residue ${clickedResidue.molName}/${clickedResidue.chain}/${clickedResidue.seqNum}`)
-        } else {
-            let selectedResidueAtoms = props.molecules[selectedMoleculeIndex].cachedAtoms.atoms[selectedModelIndex].chains[selectedChainIndex].residues[selectedResidueIndex].atoms;
-            props.glRef.current.setOrigin(props.molecules[selectedMoleculeIndex].cachedAtoms.atoms[selectedModelIndex].centreOnAtoms(selectedResidueAtoms))
-        }
     }, [clickedResidue])
 
 

--- a/react-app/src/Ramachandran.js
+++ b/react-app/src/Ramachandran.js
@@ -187,7 +187,8 @@ class RamaPlot extends Component {
         if(this.state.plotInfo){
             const hit = this.getHit(event,self);
             if(this.props.onClick&&hit>-1){
-                this.props.onClick({coordMolNo:this.state.coordMolNo, molName:this.state.molName, chain:this.state.chainId, seqNum:this.state.plotInfo[hit].seqNum, insCode:this.state.plotInfo[hit].insCode});
+                // WARNING: ALWAYS ASSUMING FIRST MODEL IN MOLECULE
+                this.props.onClick({modelIndex:0, coordMolNo:this.state.coordMolNo, molName:this.state.molName, chain:this.state.chainId, seqNum:this.state.plotInfo[hit].seqNum, insCode:this.state.plotInfo[hit].insCode});
             }
         }
     }

--- a/react-app/src/SequenceViewer.js
+++ b/react-app/src/SequenceViewer.js
@@ -321,7 +321,8 @@ class SequenceViewer extends Component {
             const resNum = ic-this.xoff+2;
             const molName = name.replace(re,"");
             if(this.props.onDoubleClick){
-                this.props.onDoubleClick({molName:molName,chain:chain,seqNum:resNum});
+                // WARNING: ALWAYS ASSUMING FIRST MODEL IN MOLECULE
+                this.props.onDoubleClick({modelIndex:0, molName:molName, chain:chain, seqNum:resNum});
             }
         }
     }


### PR DESCRIPTION
Sorry this was meant to go in the previous PR. I've enabled the `selection` argument in  `BabyGruMolecule.centreOn`. I am not sure if this is what @martinemnoble1 had in mind when writing this, but with this implementation `selection` would be expected to be an object with the attributes `modelIndex` `molName` `chain` and `seqNum`. This change means less code repetition between `BabyGruRamachandran` and `BabyGruSequenceViewer`.