### PR TITLE
Assing sequence to copied fragments

### DIFF
--- a/baby-gru/public/CootWorker.js
+++ b/baby-gru/public/CootWorker.js
@@ -48,6 +48,15 @@ const floatArrayToJSArray = (floatArray) => {
     return returnResult;
 }
 
+const residueCodesToJSArray = (residueCodes) => {
+    let returnResult = []
+    for(let ic=0; ic < residueCodes.size(); ic++){
+        returnResult.push({"resNum": residueCodes.get(ic).first.res_no, "resCode": residueCodes.get(ic).second})
+    }
+    return returnResult
+
+}
+
 const simpleMeshToLineMeshData = (simpleMesh) => {
     const vertices = simpleMesh.vertices;
     const triangles = simpleMesh.triangles;
@@ -249,27 +258,27 @@ onmessage = function (e) {
             else {
                 cootResult = molecules_container[command](...commandArgs)
             }
-            //console.log('Here')
+
             let returnResult;
-            //console.log('And Here')
+
             switch (returnType) {
                 case 'mesh':
                     returnResult = simpleMeshToMeshData(cootResult)
-                    //returnResult = simpleMeshToLineMeshData(cootResult)
                     break;
                 case 'lines_mesh':
                     returnResult = simpleMeshToLineMeshData(cootResult)
-                    //returnResult = simpleMeshToLineMeshData(cootResult)
                     break;
                 case 'float_array':
                     returnResult = floatArrayToJSArray(cootResult)
                     break;
+                case 'residue_codes':
+                    returnResult = residueCodesToJSArray(cootResult)
+                    break;                    
                 case 'status':
                 default:
                     returnResult = cootResult
                     break;
             }
-            //console.log('And also Here')
 
             postMessage({
                 returnType, command, commandArgs, message, messageId, myTimeStamp,

--- a/baby-gru/src/components/BabyGruDisplayObjects.js
+++ b/baby-gru/src/components/BabyGruDisplayObjects.js
@@ -40,13 +40,7 @@ export const BabyGruMoleculeCard = (props) => {
 
     const copyFragment = () => {
         async function createNewFragmentMolecule() {
-            const inputData = {message:"copy_fragment", coordMolNo:clickedResidue.coordMolNo, chainId:clickedResidue.chain, res_no_start:selectedResidues[0], res_no_end:selectedResidues[1]}
-            const response = await props.commandCentre.current.postMessage(inputData)
-            const newMolecule = new BabyGruMolecule(props.commandCentre)
-            newMolecule.name = `${props.molecule.name} fragment`
-            await newMolecule.loadFromCoordMolNo(response.data.result)
-            await newMolecule.fetchIfDirtyAndDraw('bonds', props.glRef)
-            await newMolecule.centreOn(props.glRef)
+            const newMolecule = await props.molecule.copyFragment(clickedResidue.chain, selectedResidues[0], selectedResidues[1], props.glRef)
             props.setMolecules([...props.molecules, newMolecule])         
         }
         

--- a/baby-gru/src/components/BabyGruMolecule.js
+++ b/baby-gru/src/components/BabyGruMolecule.js
@@ -37,6 +37,13 @@ BabyGruMolecule.prototype.copyFragment = async function (chainId, res_no_start, 
     newMolecule.coordMolNo = response.data.result
     await newMolecule.fetchIfDirtyAndDraw('bonds', gl)
     await newMolecule.centreOn(gl)
+    
+    const sequenceInputData = { returnType: "residue_codes", command:"get_single_letter_codes_for_chain", commandArgs:[response.data.result, chainId]}
+    const sequenceResponse = await $this.commandCentre.current.cootCommand(sequenceInputData)
+    newMolecule.cachedAtoms.sequences = [{
+        sequence: sequenceResponse.data.result.result.map(residue => residue.resCode).join('')
+    }]
+
     return newMolecule
 }
 

--- a/baby-gru/src/components/BabyGruMolecule.js
+++ b/baby-gru/src/components/BabyGruMolecule.js
@@ -27,6 +27,19 @@ export function BabyGruMolecule(commandCentre) {
     }
 };
 
+
+BabyGruMolecule.prototype.copyFragment = async function (chainId, res_no_start, res_no_end, gl) {
+    const $this = this
+    const inputData = {message:"copy_fragment", coordMolNo:$this.coordMolNo, chainId:chainId, res_no_start:res_no_start, res_no_end:res_no_end}
+    const response = await $this.commandCentre.current.postMessage(inputData)
+    const newMolecule = new BabyGruMolecule($this.commandCentre)
+    newMolecule.name = `${$this.name} fragment`
+    newMolecule.coordMolNo = response.data.result
+    await newMolecule.fetchIfDirtyAndDraw('bonds', gl)
+    await newMolecule.centreOn(gl)
+    return newMolecule
+}
+
 BabyGruMolecule.prototype.loadToCootFromFile = function (source) {
     const $this = this
     const pdbRegex = /.pdb$/;

--- a/web_example/coot_example.cc
+++ b/web_example/coot_example.cc
@@ -600,6 +600,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("geometry_init_standard",&molecules_container_t::geometry_init_standard)
     .function("fill_rotamer_probability_tables",&molecules_container_t::fill_rotamer_probability_tables)
     .function("copy_fragment_using_residue_range",&molecules_container_t::copy_fragment_using_residue_range)
+    .function("get_single_letter_codes_for_chain",&molecules_container_t::get_single_letter_codes_for_chain)
     .function("undo",&molecules_container_t::undo)
     .function("redo",&molecules_container_t::redo)
     .function("refine_residues_using_atom_cid",&molecules_container_t::refine_residues_using_atom_cid)


### PR DESCRIPTION
This update fixes fragment copy (it was missing a function in the last PR). Also, copied fragments will be assigned a sequence corresponding to the observed residues using the api function `get_single_letter_codes_for_chain`. As suggested, to do this a new `returnType` has been defined and `commandCentre.cootCommand` is being used. There is one issueat the moment: the current sequence viewer assumes that the residue numbering starts at 1, which is not always the case specially when dealing with a copied fragment. Because of this, residue selection using the sequence viewer on the copied fragment doesn't work. This issue is external to the sequence viewer itself, at the moment the object `BabyGruMolecule.cachedAtoms.sequences` does not inform of residue numbering. We might need to think about how to update this object to store data about residue numbering as well. But I think this can be dealt with in a different PR as it will affect the sequence viewer and the parser functions at `gMinimol.js`, not the fragment copy.