### PR TITLE
Enable molecule deletion

### DIFF
--- a/baby-gru/public/CootWorker.js
+++ b/baby-gru/public/CootWorker.js
@@ -241,6 +241,17 @@ onmessage = function (e) {
         })
     }
 
+    else if (e.data.message === 'delete') {
+        const result = molecules_container.close_molecule(e.data.coordMolNo)
+ 
+        postMessage({
+            messageId: e.data.messageId,
+            myTimeStamp: e.data.myTimeStamp,
+            messageTag: "result",
+            result: result,
+        })
+    }
+
     if (e.data.message === 'coot_command') {
         const { returnType, command, commandArgs, message, messageId, myTimeStamp } = e.data
         try {

--- a/baby-gru/src/components/BabyGruDisplayObjects.js
+++ b/baby-gru/src/components/BabyGruDisplayObjects.js
@@ -38,7 +38,7 @@ export const BabyGruMoleculeCard = (props) => {
 
     }, [clickedResidue]);
 
-    const copyFragment = () => {
+    const handleCopyFragment = () => {
         async function createNewFragmentMolecule() {
             const newMolecule = await props.molecule.copyFragment(clickedResidue.chain, selectedResidues[0], selectedResidues[1], props.glRef)
             props.setMolecules([...props.molecules, newMolecule])         
@@ -48,6 +48,12 @@ export const BabyGruMoleculeCard = (props) => {
         if(clickedResidue && selectedResidues){
             createNewFragmentMolecule()
         }
+    }
+
+    const handleDeleteMolecule = () => {
+        let newMoleculesList = props.molecules.filter(molecule => molecule.coordMolNo !== props.molecule.coordMolNo)
+        props.setMolecules(newMoleculesList)
+        props.molecule.delete(props.glRef);
     }
 
     const handleMoleculeRename = () => {
@@ -127,7 +133,8 @@ export const BabyGruMoleculeCard = (props) => {
                         <DownloadOutlined />
                     </Button>
                     <DropdownButton size="sm" variant="outlined">
-                        <Dropdown.Item as="button" onClick={copyFragment}>Copy selected residues into fragment</Dropdown.Item>
+                        <Dropdown.Item as="button" onClick={handleCopyFragment}>Copy selected residues into fragment</Dropdown.Item>
+                        <Dropdown.Item as="button" onClick={handleDeleteMolecule}>Delete molecule</Dropdown.Item>
                         <Dropdown.Item as="button" onClick={() => {setShowRenameModal(true)}}>Rename molecule</Dropdown.Item>
                     </DropdownButton>
                 </Col>

--- a/baby-gru/src/components/BabyGruMolecule.js
+++ b/baby-gru/src/components/BabyGruMolecule.js
@@ -28,6 +28,16 @@ export function BabyGruMolecule(commandCentre) {
 };
 
 
+BabyGruMolecule.prototype.delete = async function (gl) {
+    const $this = this
+    Object.getOwnPropertyNames(this.displayObjects).forEach(displayObject => {
+        if(this.displayObjects[displayObject].length > 0) {this.hide(displayObject, gl)}
+    })
+    const inputData = {message:"delete", coordMolNo:$this.coordMolNo}
+    const response = await $this.commandCentre.current.postMessage(inputData)
+    return response
+}
+
 BabyGruMolecule.prototype.copyFragment = async function (chainId, res_no_start, res_no_end, gl) {
     const $this = this
     const inputData = {message:"copy_fragment", coordMolNo:$this.coordMolNo, chainId:chainId, res_no_start:res_no_start, res_no_end:res_no_end}

--- a/baby-gru/src/components/BabyGruRamachandran.js
+++ b/baby-gru/src/components/BabyGruRamachandran.js
@@ -80,7 +80,7 @@ export const BabyGruRamachandran = (props) => {
 
     useEffect(() => {
         console.log('selectedModel changed', selectedModel)
-        if (selectedModel !== null) {
+        if (selectedModel !== null && props.molecules[selectedModel]) {
             setCachedAtoms(props.molecules[selectedModel].cachedAtoms)
         }
     })

--- a/baby-gru/src/components/BabyGruSequenceViewer.js
+++ b/baby-gru/src/components/BabyGruSequenceViewer.js
@@ -74,6 +74,11 @@ export const BabyGruSequenceViewer = (props) => {
      * and mouse over. It will also disable mouse double click.
      */
     useEffect(()=> {
+        
+        if (sequenceRef.current === null) {
+            return;
+        }
+
         const handleChange = (evt) => {
             if (evt.detail.eventtype === "click") {
                 if (evt.detail.feature !== null && !(evt.detail.highlight.includes(','))) {
@@ -100,10 +105,11 @@ export const BabyGruSequenceViewer = (props) => {
         sequenceRef.current.addEventListener("change", handleChange)
         sequenceRef.current.addEventListener('dblclick', disableDoubleClick, true)
 
-        // TODO: Need to double check that this is actually removing the event listeners
         return () => {
-            sequenceRef.current.removeEventListener('change', handleChange);
-            sequenceRef.current.removeEventListener('dblclick', disableDoubleClick, true);
+            if (sequenceRef && sequenceRef.current) {
+                sequenceRef.current.removeEventListener('change', handleChange);
+                sequenceRef.current.removeEventListener('dblclick', disableDoubleClick, true);
+            }
         };
         
       }, []);    

--- a/web_example/coot_example.cc
+++ b/web_example/coot_example.cc
@@ -600,7 +600,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("geometry_init_standard",&molecules_container_t::geometry_init_standard)
     .function("fill_rotamer_probability_tables",&molecules_container_t::fill_rotamer_probability_tables)
     .function("copy_fragment_using_residue_range",&molecules_container_t::copy_fragment_using_residue_range)
-    .function("get_single_letter_codes_for_chain",&molecules_container_t::get_single_letter_codes_for_chain)
+    .function("close_molecule",&molecules_container_t::close_molecule)
     .function("undo",&molecules_container_t::undo)
     .function("redo",&molecules_container_t::redo)
     .function("refine_residues_using_atom_cid",&molecules_container_t::refine_residues_using_atom_cid)


### PR DESCRIPTION
This update enables molecule deletion. This is done in the following order:

1. Remove molecule from `props.molecules`. This has a knock-on effect on the children components `BabyGruRamachandran` and `BabyGruSequenceViewer` which have hooks listening to `props.molecules` and would break because it is now null/undefined. Because of this, some hooks had to be updated to check if `props.molecules[selectedModel]` and `sequenceRef.current` are defined. Is there a cleaner way of doing this @stuartjamesmcnicholas / @martinemnoble1 ?
4. Hide all display objects related to the current molecule. I am also not sure if this is the best way to do this, by hiding the display objects are we really removing this from the memory or is it still stored somewhere and they are just not visible?
5. Remove molecule using coot api. I believe this bit is OK.

I also removed the duplicated `get_single_letter_codes_for_chain` function from `molecules_container_t`