### PR TITLE
Fix side bar width issues

### DIFF
--- a/baby-gru/src/components/BabyGruContainer.css
+++ b/baby-gru/src/components/BabyGruContainer.css
@@ -13,3 +13,9 @@
 .validation-plot-div{
     height: calc(100% - 4rem);
 }
+
+::-webkit-scrollbar {
+    width: 0px;
+    background: transparent; 
+    -webkit-padding-end: 16px;
+  }

--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -51,7 +51,7 @@ export const BabyGruContainer = (props) => {
 
     const sideBarWidth = convertViewtoPx(30, windowWidth)
     const innerWindowMarginHeight = convertRemToPx(2.1)
-    const innerWindowMarginWidth = convertRemToPx(5)
+    const innerWindowMarginWidth = convertRemToPx(1)
 
     const setWindowDimensions = () => {
         setWindowWidth(window.innerWidth)


### PR DESCRIPTION
I think this addresses the issues of the side bar rendering below the visualisation panel. The problem is the scroll bar in chrome is wider than in firefox and it takes space in the margin of the div whereas firefox seems to place it in the padding. For now I have made the scrollbar invisible in chrome. While non-ideal I believe this fixes the issue and I would like to know if the people with smaller displays still have the same problem in chrome after this update or if this is a step on the right direction.