### PR TITLE
Do not close dropdown menu if popover is open

### DIFF
--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -238,7 +238,7 @@ export const BabyGruContainer = (props) => {
                         <BabyGruButtonBar {...collectedProps} />
                     </div>
                 </Col>
-                <Col style={{ padding: '0.5rem', margin: '0', display: showSideBar ? "Block" : "None" }} >
+                <Col style={{ padding: '0.5rem', margin: '0', display: showSideBar ? "block" : "none" }} >
                     <Accordion style={{ height: accordionHeight, overflowY: 'scroll' }}
                         alwaysOpen={true}
                         defaultActiveKey={''}

--- a/baby-gru/src/components/BabyGruFileMenu.js
+++ b/baby-gru/src/components/BabyGruFileMenu.js
@@ -14,6 +14,8 @@ export const BabyGruFileMenu = (props) => {
     const [overlayVisible, setOverlayVisible] = useState(false)
     const [overlayContent, setOverlayContent] = useState(<></>)
     const [overlayTarget, setOverlayTarget] = useState(null)
+    const [dropdownIsShown, setDropdownIsShown] = useState(false)
+    const [popoverIsShown, setPopoverIsShown] = useState(false)
     const readMtzTarget = useRef(null);
     const readDictionaryTarget = useRef(null);
     const pdbCodeFetchInputRef = useRef(null);
@@ -66,7 +68,7 @@ export const BabyGruFileMenu = (props) => {
     }
 
     return <>
-        <NavDropdown title="File" id="basic-nav-dropdown">
+        <NavDropdown title="File" id="basic-nav-dropdown" autoClose={popoverIsShown ? false : 'outside'} onToggle={() => setDropdownIsShown(!dropdownIsShown)} show={dropdownIsShown}>
             <Form.Group style={{ width: '20rem', margin: '0.5rem' }} controlId="uploadCoords" className="mb-3">
                 <Form.Label>Coordinates</Form.Label>
                 <Form.Control type="file" accept=".pdb, .mmcif, .ent" multiple={true} onChange={(e) => { loadPdbFiles(e.target.files) }} />
@@ -85,13 +87,13 @@ export const BabyGruFileMenu = (props) => {
                 </InputGroup>
             </Form.Group>
 
-            <BabyGruImportMapCoefficientsMenuItem {...props} />
+            <BabyGruImportMapCoefficientsMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
 
-            <BabyGruImportDictionaryMenuItem {...props} />
+            <BabyGruImportDictionaryMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
 
-            <BabyGruLoadTutorialDataMenuItem {...props} />
+            <BabyGruLoadTutorialDataMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
 
-            <BabyGruDeleteEverythingMenuItem {...props}/>
+            <BabyGruDeleteEverythingMenuItem setPopoverIsShown={setPopoverIsShown} {...props}/>
 
         </NavDropdown>
 

--- a/baby-gru/src/components/BabyGruHistoryMenu.js
+++ b/baby-gru/src/components/BabyGruHistoryMenu.js
@@ -10,6 +10,8 @@ import { BabyGruMergeMoleculesMenuItem } from "./BabyGruMenuItem";
 export const BabyGruHistoryMenu = (props) => {
     const [showHistory, setShowHistory] = useState(false)
     const [sessionHistory, setSessionHistory] = useState({ commands: [] })
+    const [dropdownIsShown, setDropdownIsShown] = useState(false)
+    const [popoverIsShown, setPopoverIsShown] = useState(false)
 
     useEffect(() => {
         //console.log('CommandHistory', props.commandHistory)
@@ -77,7 +79,7 @@ export const BabyGruHistoryMenu = (props) => {
     }
 
     return <>
-        <NavDropdown title="History" id="basic-nav-dropdown">
+        <NavDropdown title="History" id="basic-nav-dropdown" autoClose={popoverIsShown ? false : 'outside'} onToggle={() => setDropdownIsShown(!dropdownIsShown)} show={dropdownIsShown}>
             <MenuItem variant="success" onClick={(e) => {
                 setShowHistory(true)
             }}>Show command history</MenuItem>
@@ -93,7 +95,7 @@ export const BabyGruHistoryMenu = (props) => {
                 }} />
             </Form.Group>
 
-            <BabyGruMergeMoleculesMenuItem {...props} />
+            <BabyGruMergeMoleculesMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
 
         </NavDropdown>
         <Modal size="xl" show={showHistory} onHide={() => { setShowHistory(false) }}>

--- a/baby-gru/src/components/BabyGruLigandMenu.js
+++ b/baby-gru/src/components/BabyGruLigandMenu.js
@@ -1,17 +1,15 @@
-import { NavDropdown, Form, Button, InputGroup, Modal, FormSelect, Col, Row, Overlay, Card, FormCheck, OverlayTrigger, Tooltip, Popover } from "react-bootstrap";
-import { BabyGruMolecule } from "./BabyGruMolecule";
-import { BabyGruMap } from "./BabyGruMap";
-import { useEffect, useState, useRef, createRef } from "react";
-import { BabyGruMtzWrapper, cootCommand, readTextFile } from '../BabyGruUtils';
-import { InsertDriveFile } from "@mui/icons-material";
-import { MenuItem } from "@mui/material";
-import { BabyGruGetMonomerMenuItem, BabyGruBackgroundColorMenuItem, BabyGruImportDictionaryMenuItem } from "./BabyGruMenuItem";
+import { NavDropdown } from "react-bootstrap";
+import { useState } from "react";
+import { BabyGruGetMonomerMenuItem, BabyGruImportDictionaryMenuItem } from "./BabyGruMenuItem";
 
 export const BabyGruLigandMenu = (props) => {
+    const [dropdownIsShown, setDropdownIsShown] = useState(false)
+    const [popoverIsShown, setPopoverIsShown] = useState(false)
+
     return <>
-        <NavDropdown title="Ligand" id="basic-nav-dropdown">
-            <BabyGruGetMonomerMenuItem {...props} />
-            <BabyGruImportDictionaryMenuItem {...props} />
+        <NavDropdown title="Ligand" id="basic-nav-dropdown" autoClose={popoverIsShown ? false : 'outside'} onToggle={() => setDropdownIsShown(!dropdownIsShown)} show={dropdownIsShown} >
+            <BabyGruGetMonomerMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
+            <BabyGruImportDictionaryMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
 
         </NavDropdown>
     </>

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -61,13 +61,11 @@ export const BabyGruMapCard = (props) => {
     }, [mapContourLevel, mapRadius])
 
     useMemo(() => {
-        
         if (currentName == "") {
             return
         }
         props.map.mapName = currentName
-    
-    
+
     }, [currentName]);
 
     useEffect(() => {

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -1,8 +1,10 @@
-import { useEffect, useState, createRef, useCallback } from "react";
-import { Card, Form, Button, Row, Col, Dropdown, DropdownButton } from "react-bootstrap";
+import { useEffect, useState, createRef, useCallback, useMemo } from "react";
+import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
 import { doDownload } from '../BabyGruUtils';
 import { DownloadOutlined, VisibilityOffOutlined, VisibilityOutlined, ExpandMoreOutlined, ExpandLessOutlined } from '@mui/icons-material';
 import BabyGruSlider from "./BabyGruSlider";
+import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem } from "./BabyGruMenuItem";
+import { MenuItem } from "@mui/material";
 
 export const BabyGruMapCard = (props) => {
     const [cootContour, setCootContour] = useState(true)
@@ -10,14 +12,11 @@ export const BabyGruMapCard = (props) => {
     const [mapContourLevel, setMapContourLevel] = useState(props.initialContour)
     const [mapLitLines, setMapLitLines] = useState(props.initialMapLitLines)    
     const [isCollapsed, setIsCollapsed] = useState(false);
+    const [currentName, setCurrentName] = useState(props.map.mapName);
     const nextOrigin = createRef([])
     const busyContouring = createRef(false)
-
-    const handleDeleteMap = () => {
-        let newMapList = props.maps.filter(map => map.mapMolNo !== props.map.mapMolNo)
-        props.setMaps(newMapList)
-        props.map.delete(props.glRef);
-    }
+    const [dropdownIsShown, setDropdownIsShown] = useState(false)
+    const [popoverIsShown, setPopoverIsShown] = useState(false)
 
     const handleOriginCallback = useCallback(e => {
         nextOrigin.current = [...e.detail.map(coord => -coord)]
@@ -60,6 +59,16 @@ export const BabyGruMapCard = (props) => {
             }
         }
     }, [mapContourLevel, mapRadius])
+
+    useMemo(() => {
+        
+        if (currentName == "") {
+            return
+        }
+        props.map.mapName = currentName
+    
+    
+    }, [currentName]);
 
     useEffect(() => {
         document.addEventListener("originChanged", handleOriginCallback);
@@ -131,9 +140,10 @@ export const BabyGruMapCard = (props) => {
                         }}>
                         {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
                     </Button>
-                    <DropdownButton size="sm" variant="outlined">
-                        <Dropdown.Item as="button" onClick={handleDeleteMap}>Delete map</Dropdown.Item>
-                        <Dropdown.Item as="button" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</Dropdown.Item>
+                    <DropdownButton size="sm" variant="outlined" autoClose={popoverIsShown ? false : 'outside'} onToggle={() => setDropdownIsShown(!dropdownIsShown)} show={dropdownIsShown} >
+                        <MenuItem variant="success" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>
+                        <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />
+                        <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} setItemList={props.setMaps} itemList={props.maps} item={props.map}/>
                     </DropdownButton>
                 </Col>
             </Row>

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -587,6 +587,7 @@ export const BabyGruMergeMoleculesMenuItem = (props) => {
         for (let val of fromRef.current.value) {
             console.log('Val', val)
         }
+        props.setPopoverIsShown(false)
     }, [fromRef.current])
 
     return <BabyGruMenuItem
@@ -594,5 +595,6 @@ export const BabyGruMergeMoleculesMenuItem = (props) => {
         popoverContent={panelContent}
         menuItemText="Merge molecules..."
         onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
     />
 }

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -14,7 +14,6 @@ export const BabyGruMenuItem = (props) => {
         resolve: () => { },
         reject: () => { }
     })
-    const popoverRef = useRef(null)
 
     return <>
         {props.popoverContent ? <OverlayTrigger 
@@ -40,7 +39,7 @@ export const BabyGruMenuItem = (props) => {
             }}
             
             overlay={
-                <Popover style={{ maxWidth: "40rem" }} ref={popoverRef}>
+                <Popover style={{ maxWidth: "40rem" }}>
                     <PopoverHeader as="h3">{props.menuItemTitle}</PopoverHeader>
                     <PopoverBody>
                         {props.popoverContent}

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -1,4 +1,3 @@
-import { ShowChart } from "@mui/icons-material";
 import { MenuItem } from "@mui/material";
 import { createRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { OverlayTrigger, Popover, PopoverBody, PopoverHeader, Form, InputGroup, Button, FormSelect, Row, Col } from "react-bootstrap";

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -1,3 +1,4 @@
+import { ShowChart } from "@mui/icons-material";
 import { MenuItem } from "@mui/material";
 import { createRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { OverlayTrigger, Popover, PopoverBody, PopoverHeader, Form, InputGroup, Button, FormSelect, Row, Col } from "react-bootstrap";
@@ -14,19 +15,31 @@ export const BabyGruMenuItem = (props) => {
         resolve: () => { },
         reject: () => { }
     })
-    const popoverRef = createRef()
+    const popoverRef = useRef(null)
 
     return <>
-        {props.popoverContent ? <OverlayTrigger rootClose onEnter={() => {
-            new Promise((resolve, reject) => {
-                resolveOrRejectRef.current = { resolve, reject }
-            }).then(result => {
-                props.onCompleted("Resolve")
-                document.body.click()
-            })
-        }}
-            placement={props.popoverPlacement}
-            delay={{ show: 250, hide: 400 }}
+        {props.popoverContent ? <OverlayTrigger 
+            rootClose 
+            placement={props.popoverPlacement} 
+            trigger="click"
+
+            onEntered={() => {
+                props.setPopoverIsShown(true)
+            }}
+
+            onExited={() => {
+                props.setPopoverIsShown(false)
+            }}
+
+            onEnter={() => {            
+                new Promise((resolve, reject) => {
+                    resolveOrRejectRef.current = { resolve, reject }
+                }).then(result => {
+                    props.onCompleted("Resolve")
+                    document.body.click()
+                })
+            }}
+            
             overlay={
                 <Popover style={{ maxWidth: "40rem" }} ref={popoverRef}>
                     <PopoverHeader as="h3">{props.menuItemTitle}</PopoverHeader>
@@ -35,11 +48,10 @@ export const BabyGruMenuItem = (props) => {
                         <Button variant={props.buttonVariant} onClick={() => { resolveOrRejectRef.current.resolve() }}>{props.buttonText}</Button>
                     </PopoverBody>
                 </Popover>}
-            trigger="click"
         >
             <MenuItem className={props.textClassName} variant="success">{props.menuItemText}</MenuItem>
         </OverlayTrigger> :
-            <MenuItem variant="success">{props.menuItemText}</MenuItem>
+            <MenuItem className={props.textClassName} variant="success">{props.menuItemText}</MenuItem>
         }
     </>
 }
@@ -90,12 +102,14 @@ export const BabyGruLoadTutorialDataMenuItem = (props) => {
                 props.setMaps([...props.maps, newMap, newDiffMap])
                 props.setActiveMap(newMap)
             })
+            props.setPopoverIsShown(false)
     }
 
     return <BabyGruMenuItem
         popoverContent={panelContent}
         menuItemText="Load tutorial data..."
         onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
     />
 }
 
@@ -125,6 +139,7 @@ export const BabyGruGetMonomerMenuItem = (props) => {
                     const newMolecule = new BabyGruMolecule(props.commandCentre)
                     newMolecule.coordMolNo = result.data.result.result
                     newMolecule.name = tlcRef.current.value
+                    props.setPopoverIsShown(false)
                     newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef).then(_ => {
                         newMolecule.cachedAtoms.sequences = []
                         props.setMolecules([...props.molecules, newMolecule])
@@ -137,21 +152,23 @@ export const BabyGruGetMonomerMenuItem = (props) => {
         popoverContent={panelContent}
         menuItemText="Get monomer..."
         onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
     />
 }
 
-export const BabyGruDeleteMoleculeMenuItem = (props) => {
-
+export const BabyGruDeleteDisplayObjectMenuItem = (props) => {
+    
     const panelContent = <>
-        <Form.Group style={{ width: '10rem', margin: '0.5rem' }} controlId="BabyGruGetDeleteMoleculeMenuItem" className="mb-3">
+        <Form.Group style={{ width: '10rem', margin: '0.5rem' }} controlId="BabyGruGetDeleteMenuItem" className="mb-3">
             <span style={{ fontWeight: 'bold' }}>Are you sure?</span>
         </Form.Group>
     </>
 
     const onCompleted = () => {
-        let newMoleculesList = props.molecules.filter(molecule => molecule.coordMolNo !== props.molecule.coordMolNo)
-        props.setMolecules(newMoleculesList)
-        props.molecule.delete(props.glRef);
+        let newItemList = props.itemList.filter(item => props.item.mapMolNo ? item.mapMolNo !== props.item.mapMolNo : item.coordMolNo !== props.item.coordMolNo)
+        props.setItemList(newItemList)
+        props.item.delete(props.glRef);
+        props.setPopoverIsShown(false)
     }
 
     return <BabyGruMenuItem
@@ -162,18 +179,19 @@ export const BabyGruDeleteMoleculeMenuItem = (props) => {
         popoverContent={panelContent}
         menuItemText="Delete molecule"
         onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
     />
 }
 
-export const BabyGruRenameMoleculeMenuItem = (props) => {
-    const newNameInputRef = useRef(null)
+export const BabyGruRenameDisplayObjectMenuItem = (props) => {
+    const  newNameInputRef = useRef(null)
 
     const panelContent = <>
-        <Form.Group style={{ width: '10rem', margin: '0' }} controlId="BabyGruGetRenameMoleculeMenuItem" className="mb-3">
+        <Form.Group style={{ width: '10rem', margin: '0' }} controlId="BabyGruGetRenameMenuItem" className="mb-3">
             <Form.Control
                 ref={newNameInputRef}
                 type="text"
-                name="newMoleculeName"
+                name="newItemName"
                 placeholder="New name"
             />
         </Form.Group>
@@ -181,14 +199,20 @@ export const BabyGruRenameMoleculeMenuItem = (props) => {
 
     const onCompleted = () => {
         let newName = newNameInputRef.current.value
-        props.setMoleculeName(newName)
+        if (newName == "") {
+            return
+        }
+        props.item.name ? props.item.name = newName : props.item.mapName = newName
+        props.setCurrentName(newName)
+        props.setPopoverIsShown(false)
     }
 
     return <BabyGruMenuItem
         popoverPlacement='left'
         popoverContent={panelContent}
-        menuItemText="Rename molecule"
+        menuItemText={props.molecule ? "Rename molecule" : "Rename map"}
         onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
     />
 }
 
@@ -211,7 +235,7 @@ export const BabyGruDeleteEverythingMenuItem = (props) => {
         })
         props.setMaps([])
         props.setMolecules([])
-
+        props.setPopoverIsShown(false)
     }
 
     return <BabyGruMenuItem
@@ -221,6 +245,7 @@ export const BabyGruDeleteEverythingMenuItem = (props) => {
         popoverContent={panelContent}
         menuItemText="Delete everything"
         onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
     />
 }
 
@@ -248,7 +273,7 @@ export const BabyGruBackgroundColorMenuItem = (props) => {
             console.log('err', err)
         }
     }
-    const onCompleted = () => { }
+    const onCompleted = () => { props.setPopoverIsShown(false) }
 
     const panelContent = <>
         <SketchPicker color={backgroundColor} onChange={handleColorChange} />
@@ -265,7 +290,8 @@ export const BabyGruBackgroundColorMenuItem = (props) => {
                 <Button variant="light">Change</Button>
             </InputGroup >
         </Form.Group>}
-        onCompleted={onCompleted} />
+        onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown} />
 }
 
 export const BabyGruImportDictionaryMenuItem = (props) => {
@@ -304,12 +330,14 @@ export const BabyGruImportDictionaryMenuItem = (props) => {
             readPromises.push(readMmcifFile(file))
         }
         let mmcifReads = await Promise.all(readPromises)
+        props.setPopoverIsShown(false)
     }
 
     return <BabyGruMenuItem
         popoverContent={panelContent}
         menuItemText="Import dictionary..."
         onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
     />
 }
 
@@ -354,6 +382,7 @@ export const BabyGruImportMapCoefficientsMenuItem = (props) => {
             F: fSelectRef.current.value, PHI: phiSelectRef.current.value, W: wSelectRef.current.value,
             isDifference: isDiffRef.current.checked, useWeight: useWeightRef.current.checked
         }
+        props.setPopoverIsShown(false)
         return await handleFile(filesRef.current.files[0], selectedColumns)
     }
 
@@ -405,6 +434,19 @@ export const BabyGruImportMapCoefficientsMenuItem = (props) => {
         </Row>
     </>
 
+    return <BabyGruMenuItem
+        popoverContent={panelContent}
+        menuItemText="Map coefficients..."
+        onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
+    />
+}
+
+const BabyGruImportCoordinatesFromEBI = (props) => {
+    const panelContent = {
+
+    }
+    const onCompleted = () => { }
     return <BabyGruMenuItem
         popoverContent={panelContent}
         menuItemText="Map coefficients..."
@@ -479,11 +521,12 @@ export const BabyGruClipFogMenuItem = (props) => {
             }} />
     </div>
 
-    const onCompleted = () => { }
+    const onCompleted = () => { props.setPopoverIsShown(false) }
 
     return <BabyGruMenuItem
         popoverContent={panelContent}
         menuItemText="Clipping and fogging..."
         onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
     />
 }

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -525,44 +525,6 @@ export const BabyGruClipFogMenuItem = (props) => {
         popoverContent={panelContent}
         menuItemText="Clipping and fogging..."
         onCompleted={onCompleted}
-    />
-}
-
-export const BabyGruMergeMoleculesMenuItem = (props) => {
-    const toRef = useRef(null)
-    const fromRef = useRef(null)
-    const [selectedMolecules, setSelectedMolecules] = useState([])
-
-    const panelContent = <>
-        <BabyGruMoleculeSelect {...props} ref={toRef} />
-        <Form.Group style={{ width: '20rem', margin: '0' }} controlId="BabyGruMergeMoleculeFromMenuItem" className="mb-3">
-            <Form.Label>Molecule into which to merge</Form.Label>
-            <Form.Select
-                vaue={selectedMolecules}
-                ref={fromRef}
-                type="text"
-                multiple={true}
-                name="newMoleculeName"
-                placeholder="New name"
-                onChange={(e) => {
-                    console.log(e)
-                }}
-            >
-                {props.molecules.map(molecule => molecule.coordMolNo !== 0 && <option value={molecule}>{molecule.coordMolNo}: {molecule.name}</option>)}
-            </Form.Select>
-        </Form.Group>
-    </>
-
-    const onCompleted = useCallback(() => {
-        for (let val of fromRef.current.value) {
-            console.log('Val', val)
-        }
-    }, [fromRef.current])
-
-    return <BabyGruMenuItem
-        popoverPlacement='right'
-        popoverContent={panelContent}
-        menuItemText="Merge molecules..."
-        onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
     />
 }

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -208,7 +208,7 @@ export const BabyGruRenameDisplayObjectMenuItem = (props) => {
     return <BabyGruMenuItem
         popoverPlacement='left'
         popoverContent={panelContent}
-        menuItemText={props.molecule ? "Rename molecule" : "Rename map"}
+        menuItemText={props.item.name ? "Rename molecule" : "Rename map"}
         onCompleted={onCompleted}
         setPopoverIsShown={props.setPopoverIsShown}
     />

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -525,6 +525,44 @@ export const BabyGruClipFogMenuItem = (props) => {
         popoverContent={panelContent}
         menuItemText="Clipping and fogging..."
         onCompleted={onCompleted}
-        setPopoverIsShown={props.setPopoverIsShown}
+    />
+}
+
+export const BabyGruMergeMoleculesMenuItem = (props) => {
+    const toRef = useRef(null)
+    const fromRef = useRef(null)
+    const [selectedMolecules, setSelectedMolecules] = useState([])
+
+    const panelContent = <>
+        <BabyGruMoleculeSelect {...props} ref={toRef} />
+        <Form.Group style={{ width: '20rem', margin: '0' }} controlId="BabyGruMergeMoleculeFromMenuItem" className="mb-3">
+            <Form.Label>Molecule into which to merge</Form.Label>
+            <Form.Select
+                vaue={selectedMolecules}
+                ref={fromRef}
+                type="text"
+                multiple={true}
+                name="newMoleculeName"
+                placeholder="New name"
+                onChange={(e) => {
+                    console.log(e)
+                }}
+            >
+                {props.molecules.map(molecule => molecule.coordMolNo !== 0 && <option value={molecule}>{molecule.coordMolNo}: {molecule.name}</option>)}
+            </Form.Select>
+        </Form.Group>
+    </>
+
+    const onCompleted = useCallback(() => {
+        for (let val of fromRef.current.value) {
+            console.log('Val', val)
+        }
+    }, [fromRef.current])
+
+    return <BabyGruMenuItem
+        popoverPlacement='right'
+        popoverContent={panelContent}
+        menuItemText="Merge molecules..."
+        onCompleted={onCompleted}
     />
 }

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -32,12 +32,10 @@ export const BabyGruMoleculeCard = (props) => {
     ])
 
     useMemo(() => {
-        
         if (currentName == "") {
             return
         }
         props.molecule.name = currentName
-    
     
     }, [currentName]);
 

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -4,14 +4,16 @@ import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
 import { doDownload } from '../BabyGruUtils';
 import { DownloadOutlined, UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined } from '@mui/icons-material';
 import { BabyGruSequenceViewer } from "./BabyGruSequenceViewer";
-import { BabyGruDeleteMoleculeMenuItem, BabyGruRenameMoleculeMenuItem } from "./BabyGruMenuItem";
+import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem } from "./BabyGruMenuItem";
 
 export const BabyGruMoleculeCard = (props) => {
     const [showState, setShowState] = useState({})
     const [selectedResidues, setSelectedResidues] = useState(null);
     const [clickedResidue, setClickedResidue] = useState(null);
-    const [moleculeName, setMoleculeName] = useState(props.molecule.name);
+    const [currentName, setCurrentName] = useState(props.molecule.name);
     const [isCollapsed, setIsCollapsed] = useState(false);
+    const [dropdownIsShown, setDropdownIsShown] = useState(false)
+    const [popoverIsShown, setPopoverIsShown] = useState(false)
 
     useEffect(() => {
         const initialState = {}
@@ -31,13 +33,13 @@ export const BabyGruMoleculeCard = (props) => {
 
     useMemo(() => {
         
-        if (moleculeName == "") {
+        if (currentName == "") {
             return
         }
-        props.molecule.name = moleculeName
+        props.molecule.name = currentName
     
     
-    }, [moleculeName]);
+    }, [currentName]);
 
     useEffect(() => {
         if (!clickedResidue) {
@@ -108,10 +110,10 @@ export const BabyGruMoleculeCard = (props) => {
                         }}>
                         {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
                     </Button>
-                    <DropdownButton size="sm" variant="outlined">
+                    <DropdownButton size="sm" variant="outlined" autoClose={popoverIsShown ? false : 'outside'} onToggle={() => setDropdownIsShown(!dropdownIsShown)} show={dropdownIsShown} >
                         <MenuItem variant="success" onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>
-                        <BabyGruRenameMoleculeMenuItem setMoleculeName={setMoleculeName} {...props} />
-                        <BabyGruDeleteMoleculeMenuItem {...props}/>
+                        <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />
+                        <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} setItemList={props.setMolecules} itemList={props.molecules} item={props.molecule}/>
                     </DropdownButton>
                 </Col>
             </Row>

--- a/baby-gru/src/components/BabyGruViewMenu.js
+++ b/baby-gru/src/components/BabyGruViewMenu.js
@@ -1,17 +1,16 @@
-import { NavDropdown, Form, Overlay, Button } from "react-bootstrap";
-import { useEffect, useRef, useState } from "react";
-import BabyGruSlider from "./BabyGruSlider";
+import { NavDropdown } from "react-bootstrap";
+import { useState } from "react";
 import { BabyGruBackgroundColorMenuItem, BabyGruClipFogMenuItem } from "./BabyGruMenuItem";
 
 
 export const BabyGruViewMenu = (props) => {
-    const [overlayVisible, setOverlayVisible] = useState(false)
-    const [overlayContent, setOverlayContent] = useState(<></>)
+    const [dropdownIsShown, setDropdownIsShown] = useState(false)
+    const [popoverIsShown, setPopoverIsShown] = useState(false)
 
-    return <>
-        < NavDropdown title="View" id="basic-nav-dropdown" >
-            <BabyGruBackgroundColorMenuItem {...props} />
-            <BabyGruClipFogMenuItem {...props} />
+return <>
+        < NavDropdown title="View" id="basic-nav-dropdown" autoClose={popoverIsShown ? false : 'outside'} onToggle={() => setDropdownIsShown(!dropdownIsShown)} show={dropdownIsShown} >
+            <BabyGruBackgroundColorMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
+            <BabyGruClipFogMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
         </NavDropdown >
     </>
 }


### PR DESCRIPTION
During Stuart's demo I have noticed the dropdown menus in the navbar close when interacting with the input forms in the popovers. With this update, the dropdown menus will not close when the user clicks inside the popover. If the popover is closed, the expected behaviour is maintained (i.e. close dropdown when user clicks outside).