### PR TITLE
Execute setPopoverIsShown before exiting

### DIFF
--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -25,7 +25,7 @@ export const BabyGruMenuItem = (props) => {
                 props.setPopoverIsShown(true)
             }}
 
-            onExited={() => {
+            onExit={() => {
                 props.setPopoverIsShown(false)
             }}
 


### PR DESCRIPTION
This piece of code got lost during the merge conflict and it is essential for the effect to work every time no matter how fast you switch between menus.