### PR TITLE
Only show one dropdown at a time even when popover is shown

### DIFF
--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -51,6 +51,7 @@ export const BabyGruContainer = (props) => {
     const [accordionHeight, setAccordionHeight] = useState(convertViewtoPx(90, windowHeight))
     const [commandHistory, dispatchHistoryReducer] = useReducer(historyReducer, initialHistoryState)
     const [backgroundColor, setBackgroundColor] = useState([0., 0., 0., 1.])
+    const [currentDropdownId, setCurrentDropdownId] = useState(-1)
 
     const sideBarWidth = convertViewtoPx(30, windowWidth)
     const innerWindowMarginHeight = convertRemToPx(2.1)
@@ -176,7 +177,7 @@ export const BabyGruContainer = (props) => {
     const collectedProps = {
         molecules, setMolecules, maps, setMaps, glRef, activeMolecule, setActiveMolecule,
         activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor,
-        navBarRef
+        navBarRef, currentDropdownId, setCurrentDropdownId
     }
 
     return <> <div className="border" ref={headerRef}>
@@ -186,10 +187,10 @@ export const BabyGruContainer = (props) => {
             <Navbar.Toggle aria-controls="basic-navbar-nav" />
             <Navbar.Collapse id="basic-navbar-nav">
                 <Nav className="justify-content-left">
-                    <BabyGruFileMenu {...collectedProps} />
-                    <BabyGruHistoryMenu {...collectedProps} />
-                    <BabyGruViewMenu {...collectedProps} />
-                    <BabyGruLigandMenu {...collectedProps} />
+                    <BabyGruFileMenu dropdownId={1} {...collectedProps} />
+                    <BabyGruHistoryMenu dropdownId={2} {...collectedProps} />
+                    <BabyGruViewMenu dropdownId={3} {...collectedProps} />
+                    <BabyGruLigandMenu dropdownId={4} {...collectedProps} />
                 </Nav>
             </Navbar.Collapse>
             <Nav className="justify-content-right">

--- a/baby-gru/src/components/BabyGruFileMenu.js
+++ b/baby-gru/src/components/BabyGruFileMenu.js
@@ -14,12 +14,13 @@ export const BabyGruFileMenu = (props) => {
     const [overlayVisible, setOverlayVisible] = useState(false)
     const [overlayContent, setOverlayContent] = useState(<></>)
     const [overlayTarget, setOverlayTarget] = useState(null)
-    const [dropdownIsShown, setDropdownIsShown] = useState(false)
     const [popoverIsShown, setPopoverIsShown] = useState(false)
     const readMtzTarget = useRef(null);
     const readDictionaryTarget = useRef(null);
     const pdbCodeFetchInputRef = useRef(null);
 
+    const menuItemProps = {setPopoverIsShown, ...props}
+    
     const awaitingPromiseRef = useRef({
         resolve: () => { },
         reject: () => { }
@@ -68,7 +69,12 @@ export const BabyGruFileMenu = (props) => {
     }
 
     return <>
-        <NavDropdown title="File" id="basic-nav-dropdown" autoClose={popoverIsShown ? false : 'outside'} onToggle={() => setDropdownIsShown(!dropdownIsShown)} show={dropdownIsShown}>
+        <NavDropdown 
+                title="File" 
+                id="basic-nav-dropdown" 
+                autoClose={popoverIsShown ? false : 'outside'} 
+                show={props.currentDropdownId === props.dropdownId} 
+                onToggle={() => {props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1)}}>
             <Form.Group style={{ width: '20rem', margin: '0.5rem' }} controlId="uploadCoords" className="mb-3">
                 <Form.Label>Coordinates</Form.Label>
                 <Form.Control type="file" accept=".pdb, .mmcif, .ent" multiple={true} onChange={(e) => { loadPdbFiles(e.target.files) }} />
@@ -87,13 +93,13 @@ export const BabyGruFileMenu = (props) => {
                 </InputGroup>
             </Form.Group>
 
-            <BabyGruImportMapCoefficientsMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
+            <BabyGruImportMapCoefficientsMenuItem {...menuItemProps} />
 
-            <BabyGruImportDictionaryMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
+            <BabyGruImportDictionaryMenuItem {...menuItemProps} />
 
-            <BabyGruLoadTutorialDataMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
+            <BabyGruLoadTutorialDataMenuItem {...menuItemProps} />
 
-            <BabyGruDeleteEverythingMenuItem setPopoverIsShown={setPopoverIsShown} {...props}/>
+            <BabyGruDeleteEverythingMenuItem {...menuItemProps}/>
 
         </NavDropdown>
 

--- a/baby-gru/src/components/BabyGruHistoryMenu.js
+++ b/baby-gru/src/components/BabyGruHistoryMenu.js
@@ -77,7 +77,11 @@ export const BabyGruHistoryMenu = (props) => {
     }
 
     return <>
-        <NavDropdown title="History" id="basic-nav-dropdown">
+        <NavDropdown 
+                title="History" 
+                id="basic-nav-dropdown" 
+                show={props.currentDropdownId === props.dropdownId} 
+                onToggle={() => {props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1)}}>
             <MenuItem variant="success" onClick={(e) => {
                 setShowHistory(true)
             }}>Show command history</MenuItem>

--- a/baby-gru/src/components/BabyGruLigandMenu.js
+++ b/baby-gru/src/components/BabyGruLigandMenu.js
@@ -3,14 +3,19 @@ import { useState } from "react";
 import { BabyGruGetMonomerMenuItem, BabyGruImportDictionaryMenuItem, BabyGruMergeMoleculesMenuItem } from "./BabyGruMenuItem";
 
 export const BabyGruLigandMenu = (props) => {
-    const [dropdownIsShown, setDropdownIsShown] = useState(false)
     const [popoverIsShown, setPopoverIsShown] = useState(false)
+    const menuItemProps = {setPopoverIsShown, ...props}
 
     return <>
-        <NavDropdown title="Ligand" id="basic-nav-dropdown" autoClose={popoverIsShown ? false : 'outside'} onToggle={() => setDropdownIsShown(!dropdownIsShown)} show={dropdownIsShown} >
-            <BabyGruGetMonomerMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
-            <BabyGruImportDictionaryMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
-            <BabyGruMergeMoleculesMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
+        <NavDropdown 
+                title="Ligand" 
+                id="basic-nav-dropdown" 
+                autoClose={popoverIsShown ? false : 'outside'} 
+                show={props.currentDropdownId === props.dropdownId} 
+                onToggle={() => {props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1)}}>
+            <BabyGruGetMonomerMenuItem {...menuItemProps} />
+            <BabyGruImportDictionaryMenuItem {...menuItemProps} />
+            <BabyGruMergeMoleculesMenuItem {...menuItemProps} />
         </NavDropdown>
     </>
 }

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -1,6 +1,5 @@
-import { ConnectingAirportsOutlined } from "@mui/icons-material";
 import { MenuItem } from "@mui/material";
-import { createRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { OverlayTrigger, Popover, PopoverBody, PopoverHeader, Form, InputGroup, Button, FormSelect, Row, Col } from "react-bootstrap";
 import { SketchPicker } from "react-color";
 import { BabyGruMtzWrapper, readTextFile } from "../BabyGruUtils";

--- a/baby-gru/src/components/BabyGruValidation.js
+++ b/baby-gru/src/components/BabyGruValidation.js
@@ -1,11 +1,6 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from "react"
 import { Col, Row, Form } from 'react-bootstrap';
-import { Ramachandran } from "../WebGL/Ramachandran"
-import { cootCommand, postCootMessage } from "../BabyGruUtils"
-import { inspect } from 'util'
 import { Chart, registerables } from 'chart.js';
-import { convertRemToPx } from '../BabyGruUtils';
-import { ConnectingAirportsOutlined } from "@mui/icons-material";
 
 Chart.register(...registerables);
 

--- a/baby-gru/src/components/BabyGruViewMenu.js
+++ b/baby-gru/src/components/BabyGruViewMenu.js
@@ -4,14 +4,19 @@ import { BabyGruBackgroundColorMenuItem, BabyGruClipFogMenuItem } from "./BabyGr
 
 
 export const BabyGruViewMenu = (props) => {
-    const [dropdownIsShown, setDropdownIsShown] = useState(false)
     const [popoverIsShown, setPopoverIsShown] = useState(false)
+    const menuItemProps = {setPopoverIsShown, ...props}
 
-return <>
-        < NavDropdown title="View" id="basic-nav-dropdown" autoClose={popoverIsShown ? false : 'outside'} onToggle={() => setDropdownIsShown(!dropdownIsShown)} show={dropdownIsShown} >
-            <BabyGruBackgroundColorMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
-            <BabyGruClipFogMenuItem setPopoverIsShown={setPopoverIsShown} {...props} />
-        </NavDropdown >
-    </>
-}
+    return <>
+            < NavDropdown 
+                    title="View" 
+                    id="basic-nav-dropdown" 
+                    autoClose={popoverIsShown ? false : 'outside'}
+                    show={props.currentDropdownId === props.dropdownId}
+                    onToggle={() => {props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1)}}>
+                <BabyGruBackgroundColorMenuItem {...menuItemProps} />
+                <BabyGruClipFogMenuItem {...menuItemProps} />
+            </NavDropdown >
+        </>
+    }
 


### PR DESCRIPTION
After #39, if a popover is shown and the user clicks in a different dropdown, the popover will close but not the previous dropdown. This update fixes this and refactors some code.