### PR TITLE
Small update to display cards

### DIFF
--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -1,7 +1,7 @@
-import { useEffect, useState, createRef, useCallback, useMemo } from "react";
+import { useEffect, useState, createRef, useCallback, useMemo, Fragment } from "react";
 import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
 import { doDownload } from '../utils/BabyGruUtils';
-import { VisibilityOffOutlined, VisibilityOutlined, ExpandMoreOutlined, ExpandLessOutlined } from '@mui/icons-material';
+import { VisibilityOffOutlined, VisibilityOutlined, ExpandMoreOutlined, ExpandLessOutlined, DownloadOutlined } from '@mui/icons-material';
 import BabyGruSlider from "./BabyGruSlider";
 import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem } from "./BabyGruMenuItem";
 import { MenuItem } from "@mui/material";
@@ -21,6 +21,69 @@ export const BabyGruMapCard = (props) => {
     const handleDownload = async () => {
         let response = await props.map.getMap()
         doDownload([response.data.result.mapData], `${props.map.mapName.replace('.mtz', '.map')}`)
+    }
+
+    const handleVisibility = () => {
+        if (!cootContour) {
+            props.map.makeCootLive(props.glRef.current, mapRadius)
+            setCootContour(true)
+        } else {
+            props.map.makeCootUnlive(props.glRef.current)
+            setCootContour(false)
+        }
+    }
+
+    const getButtonBar = (availableWidth) => {
+
+        if (availableWidth <= 600) {
+            return <Fragment>
+                        <Button size="sm" variant="outlined" onClick={handleVisibility}>
+                            {cootContour ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
+                        </Button>
+                        <DropdownButton 
+                                size="sm" 
+                                variant="outlined" 
+                                autoClose={popoverIsShown ? false : 'outside'} 
+                                show={props.currentDropdownMolNo === props.map.molNo} 
+                                onToggle={() => {props.map.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.map.molNo) : props.setCurrentDropdownMolNo(-1)}}>
+                            <MenuItem variant="success" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>
+                            <MenuItem variant="success" onClick={handleDownload}>Download map</MenuItem>
+                            <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />
+                            <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
+                        </DropdownButton>
+                        <Button size="sm" variant="outlined"
+                            onClick={() => {
+                                setIsCollapsed(!isCollapsed)
+                            }}>
+                            {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
+                        </Button>
+                    </Fragment>
+        } else {
+            return <Fragment>
+                        <Button size="sm" variant="outlined" onClick={handleVisibility}>
+                            {cootContour ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
+                        </Button>
+                        <Button size="sm" variant="outlined" onClick={handleDownload}>
+                            <DownloadOutlined />
+                        </Button>
+                        <DropdownButton 
+                                size="sm" 
+                                variant="outlined" 
+                                autoClose={popoverIsShown ? false : 'outside'} 
+                                show={props.currentDropdownMolNo === props.map.molNo} 
+                                onToggle={() => {props.map.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.map.molNo) : props.setCurrentDropdownMolNo(-1)}}>
+                            <MenuItem variant="success" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>
+                            <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />
+                            <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
+                        </DropdownButton>
+                        <Button size="sm" variant="outlined"
+                            onClick={() => {
+                                setIsCollapsed(!isCollapsed)
+                            }}>
+                            {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
+                        </Button>
+                    </Fragment>
+        }
     }
 
     const handleOriginCallback = useCallback(e => {
@@ -112,38 +175,10 @@ export const BabyGruMapCard = (props) => {
             <Row className='align-items-center'>
             <Col style={{display:'flex', justifyContent:'left'}}>
                     {`#${props.map.molNo} Map ${props.map.mapName}`}
-                </Col>
-                <Col style={{display:'flex', justifyContent:'right'}}>
-                    <Button size="sm" variant="outlined" onClick={() => {
-                        console.log(mapRadius)
-                        if (!cootContour) {
-                            props.map.makeCootLive(props.glRef.current, mapRadius)
-                            setCootContour(true)
-                        } else {
-                            props.map.makeCootUnlive(props.glRef.current)
-                            setCootContour(false)
-                        }
-                    }}>
-                        {cootContour ? <VisibilityOffOutlined /> : <VisibilityOutlined /> }
-                    </Button>
-                    <DropdownButton 
-                            size="sm" 
-                            variant="outlined" 
-                            autoClose={popoverIsShown ? false : 'outside'} 
-                            show={props.currentDropdownMolNo === props.map.molNo} 
-                            onToggle={() => {props.map.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.map.molNo) : props.setCurrentDropdownMolNo(-1)}}>
-                        <MenuItem variant="success" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>
-                        <MenuItem variant="success" onClick={handleDownload}>Download map</MenuItem>
-                        <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />
-                        <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
-                    </DropdownButton>
-                    <Button size="sm" variant="outlined"
-                        onClick={() => {
-                            setIsCollapsed(!isCollapsed)
-                        }}>
-                        {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
-                    </Button>
-                </Col>
+            </Col>
+            <Col style={{display:'flex', justifyContent:'right'}}>
+                {getButtonBar(props.sideBarWidth)}
+            </Col>
             </Row>
         </Card.Header>
         <Card.Body style={{display: isCollapsed ? 'none' : ''}}>

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, createRef, useCallback, useMemo } from "react";
 import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
 import { doDownload } from '../utils/BabyGruUtils';
-import { DownloadOutlined, VisibilityOffOutlined, VisibilityOutlined, ExpandMoreOutlined, ExpandLessOutlined } from '@mui/icons-material';
+import { VisibilityOffOutlined, VisibilityOutlined, ExpandMoreOutlined, ExpandLessOutlined } from '@mui/icons-material';
 import BabyGruSlider from "./BabyGruSlider";
 import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem } from "./BabyGruMenuItem";
 import { MenuItem } from "@mui/material";

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -18,6 +18,11 @@ export const BabyGruMapCard = (props) => {
     const [dropdownIsShown, setDropdownIsShown] = useState(false)
     const [popoverIsShown, setPopoverIsShown] = useState(false)
 
+    const handleDownload = async () => {
+        let response = await props.map.getMap()
+        doDownload([response.data.result.mapData], `${props.map.mapName.replace('.mtz', '.map')}`)
+    }
+
     const handleOriginCallback = useCallback(e => {
         nextOrigin.current = [...e.detail.map(coord => -coord)]
         if (props.map.cootContour) {
@@ -119,24 +124,7 @@ export const BabyGruMapCard = (props) => {
                             setCootContour(false)
                         }
                     }}>
-                        {cootContour ? <VisibilityOutlined /> : <VisibilityOffOutlined />}
-                    </Button>
-                    <Button size="sm" variant="outlined"
-                        onClick={() => {
-                            props.map.getMap()
-                                .then(reply => {
-                                    doDownload([reply.data.result.mapData],
-                                        `${props.map.name.replace('.mtz', '.map')}`
-                                    )
-                                })
-                        }}>
-                        <DownloadOutlined />
-                    </Button>
-                    <Button size="sm" variant="outlined"
-                        onClick={() => {
-                            setIsCollapsed(!isCollapsed)
-                        }}>
-                        {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
+                        {cootContour ? <VisibilityOffOutlined /> : <VisibilityOutlined /> }
                     </Button>
                     <DropdownButton 
                             size="sm" 
@@ -145,9 +133,16 @@ export const BabyGruMapCard = (props) => {
                             show={props.currentDropdownMolNo === props.map.molNo} 
                             onToggle={() => {props.map.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.map.molNo) : props.setCurrentDropdownMolNo(-1)}}>
                         <MenuItem variant="success" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>
+                        <MenuItem variant="success" onClick={handleDownload}>Download map</MenuItem>
                         <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />
                         <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
                     </DropdownButton>
+                    <Button size="sm" variant="outlined"
+                        onClick={() => {
+                            setIsCollapsed(!isCollapsed)
+                        }}>
+                        {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
+                    </Button>
                 </Col>
             </Row>
         </Card.Header>

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -2,7 +2,7 @@ import { MenuItem } from "@mui/material";
 import { useEffect, useState, useMemo } from "react";
 import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
 import { doDownload } from '../utils/BabyGruUtils';
-import { DownloadOutlined, UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined } from '@mui/icons-material';
+import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined } from '@mui/icons-material';
 import { BabyGruSequenceViewer } from "./BabyGruSequenceViewer";
 import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem } from "./BabyGruMenuItem";
 

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -1,8 +1,8 @@
 import { MenuItem } from "@mui/material";
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, Fragment } from "react";
 import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
 import { doDownload } from '../utils/BabyGruUtils';
-import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined } from '@mui/icons-material';
+import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined, DownloadOutlined } from '@mui/icons-material';
 import { BabyGruSequenceViewer } from "./BabyGruSequenceViewer";
 import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem } from "./BabyGruMenuItem";
 
@@ -80,6 +80,92 @@ export const BabyGruMoleculeCard = (props) => {
         }
     }
 
+    const handleUndo = async () => {
+        await props.commandCentre.current.cootCommand({
+            returnType: "status",
+            command: "undo",
+            commandArgs: [props.molecule.molNo]
+        })
+        props.molecule.setAtomsDirty(true)
+        props.molecule.redraw(props.glRef)
+    }
+
+    const handleRedo = async () => {
+        await props.commandCentre.current.cootCommand({
+            returnType: "status",
+            command: "redo",
+            commandArgs: [props.molecule.molNo]
+        })
+        props.molecule.setAtomsDirty(true)
+        props.molecule.redraw(props.glRef)
+    }
+
+    const getButtonBar = (availableWidth) => {
+
+        if (availableWidth <= 600) {
+            return <Fragment>
+                        <Button size="sm" variant="outlined" onClick={handleVisibility}>
+                            {isVisible ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
+                        </Button>
+                        <DropdownButton 
+                                size="sm" 
+                                variant="outlined" 
+                                autoClose={popoverIsShown ? false : 'outside'} 
+                                show={props.currentDropdownMolNo === props.molecule.molNo} 
+                                onToggle={() => {props.molecule.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.molecule.molNo) : props.setCurrentDropdownMolNo(-1)}}>
+                            <MenuItem variant="success" onClick={() => { props.molecule.centreOn(props.glRef) }}>Center on molecule</MenuItem>
+                            <MenuItem variant="success" onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>
+                            <MenuItem variant="success" onClick={handleDownload}>Download molecule</MenuItem>
+                            <MenuItem variant="success" onClick={handleUndo}>Undo last action</MenuItem>
+                            <MenuItem variant="success" onClick={handleRedo}>Redo last action</MenuItem>
+                            <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />
+                            <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMolecules} itemList={props.molecules} item={props.molecule}/>
+                        </DropdownButton>
+                        <Button size="sm" variant="outlined"
+                            onClick={() => {
+                                setIsCollapsed(!isCollapsed)
+                            }}>
+                            {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
+                        </Button>
+                    </Fragment>
+        } else {
+            return <Fragment>
+                        <Button size="sm" variant="outlined" onClick={handleUndo}>
+                            <UndoOutlined />
+                        </Button>
+                        <Button size="sm" variant="outlined" onClick={handleRedo}>
+                            <RedoOutlined />
+                        </Button>
+                        <Button size="sm" variant="outlined"
+                            onClick={() => { props.molecule.centreOn(props.glRef) }}>
+                            <CenterFocusWeakOutlined />
+                        </Button>
+                        <Button size="sm" variant="outlined" onClick={handleVisibility}>
+                            {isVisible ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
+                        </Button>
+                        <Button size="sm" variant="outlined" onClick={handleDownload}>
+                            <DownloadOutlined />
+                        </Button>
+                        <DropdownButton 
+                                size="sm" 
+                                variant="outlined" 
+                                autoClose={popoverIsShown ? false : 'outside'} 
+                                show={props.currentDropdownMolNo === props.molecule.molNo} 
+                                onToggle={() => {props.molecule.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.molecule.molNo) : props.setCurrentDropdownMolNo(-1)}}>
+                            <MenuItem variant="success" onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>
+                            <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />
+                            <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMolecules} itemList={props.molecules} item={props.molecule}/>
+                        </DropdownButton>
+                        <Button size="sm" variant="outlined"
+                            onClick={() => {
+                                setIsCollapsed(!isCollapsed)
+                            }}>
+                            {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
+                        </Button>
+                    </Fragment>
+        }
+    }
+
     return <Card className="px-0" style={{ marginBottom: '0.5rem', padding: '0' }} key={props.molecule.molNo}>
         <Card.Header>
             <Row className='align-items-center'>
@@ -87,52 +173,7 @@ export const BabyGruMoleculeCard = (props) => {
                     {`#${props.molecule.molNo} Mol. ${props.molecule.name}`}
                 </Col>
                 <Col style={{ display: 'flex', justifyContent: 'right' }}>
-                    <Button size="sm" variant="outlined"
-                        onClick={() => {
-                            props.commandCentre.current.cootCommand({
-                                returnType: "status",
-                                command: "undo",
-                                commandArgs: [props.molecule.molNo]
-                            }).then(_ => {
-                                props.molecule.setAtomsDirty(true)
-                                props.molecule.redraw(props.glRef)
-                            })
-                        }}><UndoOutlined /></Button>
-                    <Button size="sm" variant="outlined"
-                        onClick={() => {
-                            props.commandCentre.current.cootCommand({
-                                returnType: "status",
-                                command: "redo",
-                                commandArgs: [props.molecule.molNo]
-                            }).then(_ => {
-                                props.molecule.setAtomsDirty(true)
-                                props.molecule.redraw(props.glRef)
-                            })
-                        }}><RedoOutlined /></Button>
-                    <Button size="sm" variant="outlined"
-                        onClick={() => { props.molecule.centreOn(props.glRef) }}>
-                        <CenterFocusWeakOutlined />
-                    </Button>
-                    <Button size="sm" variant="outlined" onClick={handleVisibility}>
-                        {isVisible ? <VisibilityOutlined /> : <VisibilityOffOutlined />}
-                    </Button>
-                    <DropdownButton 
-                            size="sm" 
-                            variant="outlined" 
-                            autoClose={popoverIsShown ? false : 'outside'} 
-                            show={props.currentDropdownMolNo === props.molecule.molNo} 
-                            onToggle={() => {props.molecule.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.molecule.molNo) : props.setCurrentDropdownMolNo(-1)}}>
-                        <MenuItem variant="success" onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>
-                        <MenuItem variant="success" onClick={handleDownload}>Download molecule</MenuItem>
-                        <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />
-                        <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMolecules} itemList={props.molecules} item={props.molecule}/>
-                    </DropdownButton>
-                    <Button size="sm" variant="outlined"
-                        onClick={() => {
-                            setIsCollapsed(!isCollapsed)
-                        }}>
-                        {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
-                    </Button>
+                    {getButtonBar(props.sideBarWidth)}
                 </Col>
             </Row>
         </Card.Header>


### PR DESCRIPTION
Small update to the buttons on the molecule and the map cards:

- Molecule button to hide molecule representation
- Download buttons have been moved to dropdown menu
- Fixed bug where map download failed
- Re-arranged button order as requested
- Show/Hide map button icons were inverted