### PR TITLE
Fix sequence viewer bug and update UI

### DIFF
--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -5,9 +5,6 @@ import { BabyGruWebMG } from './BabyGruWebMG';
 import { BabyGruCommandCentre, convertRemToPx, convertViewtoPx } from '../utils/BabyGruUtils';
 import { BabyGruButtonBar } from './BabyGruButtonBar';
 import { BabyGruFileMenu } from './BabyGruFileMenu';
-import { BabyGruRamachandran } from './BabyGruRamachandran';
-import { BabyGruValidationPlot } from './BabyGruValidation';
-import { BabyGruTimingTest } from './BabyGruTimingTest';
 import { ArrowBackIosOutlined, ArrowForwardIosOutlined, DarkModeOutlined, LightModeOutlined } from '@mui/icons-material';
 import './BabyGruContainer.css'
 import { BabyGruHistoryMenu } from './BabyGruHistoryMenu';
@@ -206,7 +203,7 @@ export const BabyGruContainer = (props) => {
 
     const collectedProps = {
         molecules, changeMolecules, appTitle, setAppTitle, maps, changeMaps, glRef, activeMolecule, setActiveMolecule,
-        activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor,
+        activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor, sideBarWidth,
         navBarRef, currentDropdownId, setCurrentDropdownId
     }
 

--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -5,7 +5,8 @@ import { BabyGruWebMG } from './BabyGruWebMG';
 import { BabyGruCommandCentre, convertRemToPx, convertViewtoPx } from '../utils/BabyGruUtils';
 import { BabyGruButtonBar } from './BabyGruButtonBar';
 import { BabyGruFileMenu } from './BabyGruFileMenu';
-import { ArrowBackIosOutlined, ArrowForwardIosOutlined, DarkModeOutlined, LightModeOutlined } from '@mui/icons-material';
+import { BabyGruPreferencesMenu } from './BabyGruPreferencesMenu';
+import { ArrowBackIosOutlined, ArrowForwardIosOutlined } from '@mui/icons-material';
 import './BabyGruContainer.css'
 import { BabyGruHistoryMenu } from './BabyGruHistoryMenu';
 import { BabyGruViewMenu } from './BabyGruViewMenu';
@@ -45,6 +46,7 @@ export const BabyGruContainer = (props) => {
     const navBarRef = useRef()
     const [showSideBar, setShowSideBar] = useState(false)
     const [darkMode, setDarkMode] = useState(false)
+    const [defaultExpandDisplayCards, setDefaultExpandDisplayCards] = useState(true)
     const [activeMap, setActiveMap] = useState(null)
     const [activeMolecule, setActiveMolecule] = useState(null)
     const [consoleMessage, setConsoleMessage] = useState("")
@@ -204,11 +206,12 @@ export const BabyGruContainer = (props) => {
     const collectedProps = {
         molecules, changeMolecules, appTitle, setAppTitle, maps, changeMaps, glRef, activeMolecule, setActiveMolecule,
         activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor, sideBarWidth,
-        navBarRef, currentDropdownId, setCurrentDropdownId
+        navBarRef, currentDropdownId, setCurrentDropdownId, darkMode, setDarkMode, defaultExpandDisplayCards, 
+        setDefaultExpandDisplayCards
     }
 
     const accordionToolsItemProps = {
-        molecules, commandCentre, glRef, toolAccordionBodyHeight, sideBarWidth, windowHeight, windowWidth, darkMode, maps, showSideBar
+        molecules, commandCentre, glRef, toolAccordionBodyHeight, sideBarWidth, windowHeight, windowWidth, darkMode, maps, showSideBar,
     }
 
     return <> <div className="border" ref={headerRef}>
@@ -222,13 +225,11 @@ export const BabyGruContainer = (props) => {
                     <BabyGruHistoryMenu dropdownId={2} {...collectedProps} />
                     <BabyGruViewMenu dropdownId={3} {...collectedProps} />
                     <BabyGruLigandMenu dropdownId={4} {...collectedProps} />
+                    <BabyGruPreferencesMenu dropdownId={5} {...collectedProps} />
                 </Nav>
             </Navbar.Collapse>
             <Nav className="justify-content-right">
                 {busy && <Spinner animation="border" style={{ marginRight: '0.5rem' }} />}
-                <Button style={{ height: '100%', backgroundColor: darkMode ? '#222' : 'white', border: 0 }} onClick={() => { setDarkMode(darkMode ? false : true) }}>
-                    {darkMode ? <LightModeOutlined style={{ color: 'white' }} /> : <DarkModeOutlined style={{ color: 'black' }} />}
-                </Button>
                 <Button className="baby-gru-sidebar-button" style={{ height: '100%', backgroundColor: darkMode ? '#222' : 'white', border: 0 }} onClick={() => { setShowSideBar(!showSideBar) }}>
                     {showSideBar ? <ArrowForwardIosOutlined style={{ color: darkMode ? 'white' : 'black' }} /> : <ArrowBackIosOutlined style={{ color: darkMode ? 'white' : 'black' }} />}
                 </Button>

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -56,7 +56,7 @@ export const BabyGruMapCard = (props) => {
         },
         3: {
             label: mapLitLines ? "Deactivate lit lines" : "Activate lit lines",
-            compressed: () => {return (<MenuItem variant="success" onClick={handleLitLines}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>)},
+            compressed: () => {return (<MenuItem variant="success" disabled={!cootContour}  onClick={handleLitLines}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>)},
             expanded: null
         },
         4: {

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -15,12 +15,12 @@ export const BabyGruMapCard = (props) => {
     const [currentName, setCurrentName] = useState(props.map.mapName);
     const nextOrigin = createRef([])
     const busyContouring = createRef(false)
-    const [dropdownIsShown, setDropdownIsShown] = useState(false)
     const [popoverIsShown, setPopoverIsShown] = useState(false)
 
     const handleDownload = async () => {
         let response = await props.map.getMap()
         doDownload([response.data.result.mapData], `${props.map.mapName.replace('.mtz', '.map')}`)
+        props.setCurrentDropdownMolNo(-1)
     }
 
     const handleVisibility = () => {
@@ -31,6 +31,12 @@ export const BabyGruMapCard = (props) => {
             props.map.makeCootUnlive(props.glRef.current)
             setCootContour(false)
         }
+        props.setCurrentDropdownMolNo(-1)
+    }
+
+    const handleLitLines = () => {
+        setMapLitLines(!mapLitLines)
+        props.setCurrentDropdownMolNo(-1)
     }
 
     const actionButtons = {
@@ -50,7 +56,7 @@ export const BabyGruMapCard = (props) => {
         },
         3: {
             label: mapLitLines ? "Deactivate lit lines" : "Activate lit lines",
-            compressed: () => {return (<MenuItem variant="success" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>)},
+            compressed: () => {return (<MenuItem variant="success" onClick={handleLitLines}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>)},
             expanded: null
         },
         4: {

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -11,7 +11,7 @@ export const BabyGruMapCard = (props) => {
     const [mapRadius, setMapRadius] = useState(props.initialRadius)
     const [mapContourLevel, setMapContourLevel] = useState(props.initialContour)
     const [mapLitLines, setMapLitLines] = useState(props.initialMapLitLines)    
-    const [isCollapsed, setIsCollapsed] = useState(false);
+    const [isCollapsed, setIsCollapsed] = useState(!props.defaultExpandDisplayCards);
     const [currentName, setCurrentName] = useState(props.map.mapName);
     const nextOrigin = createRef([])
     const busyContouring = createRef(false)

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -33,57 +33,71 @@ export const BabyGruMapCard = (props) => {
         }
     }
 
-    const getButtonBar = (availableWidth) => {
-
-        if (availableWidth <= 600) {
-            return <Fragment>
-                        <Button size="sm" variant="outlined" onClick={handleVisibility}>
-                            {cootContour ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
-                        </Button>
-                        <DropdownButton 
-                                size="sm" 
-                                variant="outlined" 
-                                autoClose={popoverIsShown ? false : 'outside'} 
-                                show={props.currentDropdownMolNo === props.map.molNo} 
-                                onToggle={() => {props.map.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.map.molNo) : props.setCurrentDropdownMolNo(-1)}}>
-                            <MenuItem variant="success" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>
-                            <MenuItem variant="success" onClick={handleDownload}>Download map</MenuItem>
-                            <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />
-                            <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
-                        </DropdownButton>
-                        <Button size="sm" variant="outlined"
-                            onClick={() => {
-                                setIsCollapsed(!isCollapsed)
-                            }}>
-                            {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
-                        </Button>
-                    </Fragment>
-        } else {
-            return <Fragment>
-                        <Button size="sm" variant="outlined" onClick={handleVisibility}>
-                            {cootContour ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
-                        </Button>
-                        <Button size="sm" variant="outlined" onClick={handleDownload}>
-                            <DownloadOutlined />
-                        </Button>
-                        <DropdownButton 
-                                size="sm" 
-                                variant="outlined" 
-                                autoClose={popoverIsShown ? false : 'outside'} 
-                                show={props.currentDropdownMolNo === props.map.molNo} 
-                                onToggle={() => {props.map.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.map.molNo) : props.setCurrentDropdownMolNo(-1)}}>
-                            <MenuItem variant="success" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>
-                            <BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />
-                            <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
-                        </DropdownButton>
-                        <Button size="sm" variant="outlined"
-                            onClick={() => {
-                                setIsCollapsed(!isCollapsed)
-                            }}>
-                            {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
-                        </Button>
-                    </Fragment>
+    const actionButtons = {
+        1: {
+            label: "Download Map", 
+            compressed: () => {return (<MenuItem variant="success" onClick={handleDownload}>Download map</MenuItem>)},
+            expanded:  () => {return (<Button size="sm" variant="outlined" onClick={handleDownload}>
+                                        <DownloadOutlined />
+                                      </Button> )},
+        },
+        2: {
+            label: cootContour ? "Hide map" : "Show map", 
+            compressed: () => {return (<MenuItem variant="success" onClick={handleVisibility}>{cootContour ? "Hide map" : "Show map"}</MenuItem>)},
+            expanded: () => {return (<Button size="sm" variant="outlined" onClick={handleVisibility}>
+                                        {cootContour ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
+                                    </Button>)},
+        },
+        3: {
+            label: mapLitLines ? "Deactivate lit lines" : "Activate lit lines",
+            compressed: () => {return (<MenuItem variant="success" onClick={() => {setMapLitLines(!mapLitLines)}}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>)},
+            expanded: null
+        },
+        4: {
+            label: 'Rename map',
+            compressed: () => {return (<BabyGruRenameDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />)},
+            expanded: null
         }
+    }
+
+    const getButtonBar = (sideBarWidth) => {
+        const maximumAllowedWidth = sideBarWidth * 0.3
+        let currentlyUsedWidth = 0
+        let expandedButtons = []
+        let compressedButtons = []
+
+        Object.keys(actionButtons).forEach(key => {
+            if (actionButtons[key].expanded === null) {
+                compressedButtons.push(actionButtons[key].compressed())
+            } else {
+                currentlyUsedWidth += 75
+                if (currentlyUsedWidth < maximumAllowedWidth) {
+                    expandedButtons.push(actionButtons[key].expanded())
+                } else {
+                    compressedButtons.push(actionButtons[key].compressed())
+                }
+            }
+        })
+        
+        return  <Fragment>
+                    {expandedButtons}
+                    <DropdownButton 
+                            size="sm" 
+                            variant="outlined" 
+                            autoClose={popoverIsShown ? false : 'outside'} 
+                            show={props.currentDropdownMolNo === props.map.molNo} 
+                            onToggle={() => {props.map.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.map.molNo) : props.setCurrentDropdownMolNo(-1)}}>
+                        {compressedButtons}
+                        <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
+                    </DropdownButton>
+                    <Button size="sm" variant="outlined"
+                        onClick={() => {
+                            setIsCollapsed(!isCollapsed)
+                        }}>
+                        {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
+                    </Button>
+                </Fragment>
+
     }
 
     const handleOriginCallback = useCallback(e => {

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -35,18 +35,18 @@ export const BabyGruMapCard = (props) => {
 
     const actionButtons = {
         1: {
-            label: "Download Map", 
-            compressed: () => {return (<MenuItem variant="success" onClick={handleDownload}>Download map</MenuItem>)},
-            expanded:  () => {return (<Button size="sm" variant="outlined" onClick={handleDownload}>
-                                        <DownloadOutlined />
-                                      </Button> )},
-        },
-        2: {
             label: cootContour ? "Hide map" : "Show map", 
             compressed: () => {return (<MenuItem variant="success" onClick={handleVisibility}>{cootContour ? "Hide map" : "Show map"}</MenuItem>)},
             expanded: () => {return (<Button size="sm" variant="outlined" onClick={handleVisibility}>
                                         {cootContour ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
                                     </Button>)},
+        },
+        2: {
+            label: "Download Map", 
+            compressed: () => {return (<MenuItem variant="success" onClick={handleDownload}>Download map</MenuItem>)},
+            expanded:  () => {return (<Button size="sm" variant="outlined" onClick={handleDownload}>
+                                        <DownloadOutlined />
+                                      </Button> )},
         },
         3: {
             label: mapLitLines ? "Deactivate lit lines" : "Activate lit lines",
@@ -61,7 +61,7 @@ export const BabyGruMapCard = (props) => {
     }
 
     const getButtonBar = (sideBarWidth) => {
-        const maximumAllowedWidth = sideBarWidth * 0.3
+        const maximumAllowedWidth = sideBarWidth * 0.35
         let currentlyUsedWidth = 0
         let expandedButtons = []
         let compressedButtons = []
@@ -70,7 +70,7 @@ export const BabyGruMapCard = (props) => {
             if (actionButtons[key].expanded === null) {
                 compressedButtons.push(actionButtons[key].compressed())
             } else {
-                currentlyUsedWidth += 75
+                currentlyUsedWidth += 60
                 if (currentlyUsedWidth < maximumAllowedWidth) {
                     expandedButtons.push(actionButtons[key].expanded())
                 } else {
@@ -78,6 +78,10 @@ export const BabyGruMapCard = (props) => {
                 }
             }
         })
+
+        compressedButtons.push((
+            <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
+        ))
         
         return  <Fragment>
                     {expandedButtons}
@@ -88,7 +92,6 @@ export const BabyGruMapCard = (props) => {
                             show={props.currentDropdownMolNo === props.map.molNo} 
                             onToggle={() => {props.map.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.map.molNo) : props.setCurrentDropdownMolNo(-1)}}>
                         {compressedButtons}
-                        <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
                     </DropdownButton>
                     <Button size="sm" variant="outlined"
                         onClick={() => {

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -225,12 +225,12 @@ export const BabyGruMapCard = (props) => {
                 </Col>
                 <Col>
                     <Form.Group controlId="contouringLevel" className="mb-3">
-                            <BabyGruSlider minVal={0.01} maxVal={5} logScale={true} sliderTitle="Level" intialValue={props.initialContour} externalValue={mapContourLevel} setExternalValue={setMapContourLevel}/>
+                            <BabyGruSlider minVal={0.01} maxVal={5} logScale={true} sliderTitle="Level" isDisabled={!cootContour} intialValue={props.initialContour} externalValue={mapContourLevel} setExternalValue={setMapContourLevel}/>
                     </Form.Group>
                 </Col>
                 <Col>
                     <Form.Group controlId="contouringRadius" className="mb-3">
-                            <BabyGruSlider minVal={0.01} maxVal={100} logScale={false} sliderTitle="Radius" intialValue={props.initialRadius} externalValue={mapRadius} setExternalValue={setMapRadius}/>
+                            <BabyGruSlider minVal={0.01} maxVal={100} logScale={false} sliderTitle="Radius" isDisabled={!cootContour} intialValue={props.initialRadius} externalValue={mapRadius} setExternalValue={setMapRadius}/>
                     </Form.Group>
                 </Col>
             </Row>

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -12,7 +12,6 @@ export const BabyGruMoleculeCard = (props) => {
     const [clickedResidue, setClickedResidue] = useState(null);
     const [currentName, setCurrentName] = useState(props.molecule.name);
     const [isCollapsed, setIsCollapsed] = useState(false);
-    const [dropdownIsShown, setDropdownIsShown] = useState(false)
     const [popoverIsShown, setPopoverIsShown] = useState(false)
     const [isVisible, setIsVisible] = useState(true)
 
@@ -61,11 +60,13 @@ export const BabyGruMoleculeCard = (props) => {
             })
             setIsVisible(true)
         }
+        props.setCurrentDropdownMolNo(-1)
     }
 
     const handleDownload = async () => {
         let response = await props.molecule.getAtoms()
         doDownload([response.data.result.pdbData], `${props.molecule.name}`)
+        props.setCurrentDropdownMolNo(-1)
     }
 
     const handleCopyFragment = () => {
@@ -78,6 +79,7 @@ export const BabyGruMoleculeCard = (props) => {
         if (clickedResidue && selectedResidues) {
             createNewFragmentMolecule()
         }
+        props.setCurrentDropdownMolNo(-1)
     }
 
     const handleUndo = async () => {
@@ -88,6 +90,7 @@ export const BabyGruMoleculeCard = (props) => {
         })
         props.molecule.setAtomsDirty(true)
         props.molecule.redraw(props.glRef)
+        props.setCurrentDropdownMolNo(-1)
     }
 
     const handleRedo = async () => {
@@ -98,6 +101,12 @@ export const BabyGruMoleculeCard = (props) => {
         })
         props.molecule.setAtomsDirty(true)
         props.molecule.redraw(props.glRef)
+        props.setCurrentDropdownMolNo(-1)
+    }
+
+    const handleCentering = () => {
+        props.molecule.centreOn(props.glRef)
+        props.setCurrentDropdownMolNo(-1)
     }
 
     const actionButtons = {
@@ -117,8 +126,8 @@ export const BabyGruMoleculeCard = (props) => {
         },
         3: {
             label: "Center on molecule", 
-            compressed: () => {return (<MenuItem variant="success" onClick={() => { props.molecule.centreOn(props.glRef) }}>Center on molecule</MenuItem>)},
-            expanded:  () => {return (<Button size="sm" variant="outlined" onClick={() => { props.molecule.centreOn(props.glRef) }}>
+            compressed: () => {return (<MenuItem variant="success" onClick={handleCentering}>Center on molecule</MenuItem>)},
+            expanded:  () => {return (<Button size="sm" variant="outlined" onClick={handleCentering}>
                                         <CenterFocusWeakOutlined />
                                       </Button>)}
         },

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -11,7 +11,7 @@ export const BabyGruMoleculeCard = (props) => {
     const [selectedResidues, setSelectedResidues] = useState(null);
     const [clickedResidue, setClickedResidue] = useState(null);
     const [currentName, setCurrentName] = useState(props.molecule.name);
-    const [isCollapsed, setIsCollapsed] = useState(false);
+    const [isCollapsed, setIsCollapsed] = useState(!props.defaultExpandDisplayCards);
     const [popoverIsShown, setPopoverIsShown] = useState(false)
     const [isVisible, setIsVisible] = useState(true)
 

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -1,7 +1,7 @@
 import { MenuItem } from "@mui/material";
 import { useEffect, useState, useMemo, Fragment } from "react";
 import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
-import { doDownload, sequenceIsSane } from '../utils/BabyGruUtils';
+import { doDownload, sequenceIsValid } from '../utils/BabyGruUtils';
 import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined, DownloadOutlined } from '@mui/icons-material';
 import { BabyGruSequenceViewer } from "./BabyGruSequenceViewer";
 import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem } from "./BabyGruMenuItem";
@@ -266,7 +266,7 @@ export const BabyGruMoleculeCard = (props) => {
                     {props.molecule.cachedAtoms.sequences &&
                         props.molecule.cachedAtoms.sequences.map(
                             sequence => {
-                                if(!sequenceIsSane(sequence.sequence)) {
+                                if(!sequenceIsValid(sequence.sequence)) {
                                     return (
                                         <div>
                                             <p>{`Unable to parse sequence data for chain ${sequence?.chain}`}</p>

--- a/baby-gru/src/components/BabyGruPreferencesMenu.js
+++ b/baby-gru/src/components/BabyGruPreferencesMenu.js
@@ -1,0 +1,30 @@
+import { NavDropdown, Form, InputGroup } from "react-bootstrap";
+import { useState } from "react";
+
+export const BabyGruPreferencesMenu = (props) => {
+    const { darkMode, setDarkMode, defaultExpandDisplayCards, setDefaultExpandDisplayCards } = props;
+    
+    return <NavDropdown
+                    title="Preferences"
+                    id="basic-nav-dropdown"
+                    autoClose="outside"
+                    show={props.currentDropdownId === props.dropdownId}
+                    onToggle={() => { props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1) }}>
+                <InputGroup style={{ padding:'0.5rem', width: '20rem'}}>
+                    <Form.Check 
+                        type="switch"
+                        label="Expand display cards after file upload"
+                        checked={defaultExpandDisplayCards}
+                        onChange={() => { setDefaultExpandDisplayCards(!defaultExpandDisplayCards) }}
+                    />
+                </InputGroup>
+                <InputGroup style={{ padding:'0.5rem', width: '20rem'}}>
+                    <Form.Check 
+                        type="switch"
+                        checked={darkMode}
+                        onChange={() => { setDarkMode(!darkMode) }}
+                        label={darkMode ? "Switch lights on": "Switch lights off"}/>
+                </InputGroup>
+            </NavDropdown>
+
+}

--- a/baby-gru/src/components/BabyGruSequenceViewer.js
+++ b/baby-gru/src/components/BabyGruSequenceViewer.js
@@ -7,13 +7,14 @@ import ProtvistaNavigation from "protvista-navigation";
 window.customElements.define("protvista-navigation", ProtvistaNavigation);
 window.customElements.define("protvista-sequence", ProtvistaSequence);
 window.customElements.define("protvista-manager", ProtvistaManager);
-
+    
 /**
- * For a given sequence length, calculate the range of 40 residues in the middle
- * @param {Number} sequenceLength sequence lenght
- * @returns {Array} An array containing the display start and display end consisting of a range of 40 residues
- */
-const calculateDisplayStartAndEnd = (rulerStart, sequenceLength) => {
+* For a given sequence length, calculate the range of 40 residues in the middle
+* @param {Number} rulerStart integer that determines where to start the ruler numbering
+* @param {Number} sequenceLength sequence lenght
+* @returns {Array} An array containing the display start and display end consisting of a range of 40 residues
+*/
+ const calculateDisplayStartAndEnd = (rulerStart, sequenceLength) => {
     if (sequenceLength <= 40) {
         return [parseFloat(rulerStart), parseFloat(sequenceLength + rulerStart)]
     }
@@ -21,18 +22,23 @@ const calculateDisplayStartAndEnd = (rulerStart, sequenceLength) => {
     return [parseFloat(middleIndex - 20 + rulerStart), parseFloat(middleIndex + 20 + rulerStart)]        
 }
 
-
+/**
+* For a given sequence, obtain the actual sequence to be displayed with "-" as gaps
+* @param {BabyGruMolecule.sequence.sequence} sequence
+* @returns {Array} An array containing the ruler start, actual sequence length with gaps and the final sequence to be displayed
+*/
 const parseSequenceData = (sequence) => {
     let rulerStart = sequence[0].resNum
     let finalSequence = Array(sequence[sequence.length-1].resNum).fill('-')
     let seqLenght = sequence[sequence.length-1].resNum - rulerStart + 1
-    
+
     sequence.forEach(residue => {
         finalSequence[residue.resNum - 1] = residue.resCode
     })
-            
+
     return [rulerStart, seqLenght, finalSequence.join('')]
 }
+
 
 export const BabyGruSequenceViewer = (props) => {
     const managerRef = useRef(null);

--- a/baby-gru/src/components/BabyGruSlider.js
+++ b/baby-gru/src/components/BabyGruSlider.js
@@ -46,7 +46,7 @@ export default function BabyGruSlider(props) {
             <span>{props.sliderTitle}: {props.externalValue.toFixed(3)}</span>
             <Stack spacing={2} direction="row" sx={{ mb: 1 }} alignItems="center">
                 {props.minVal}
-                <Slider value={value} onChange={handleChange} />
+                <Slider disabled={props.isDisabled} value={value} onChange={handleChange} />
                 {props.maxVal}
             </Stack>
         </Box>
@@ -54,5 +54,5 @@ export default function BabyGruSlider(props) {
 }
 
 BabyGruSlider.defaultProps={
-    minVal:0, maxVal:100, setExternalValue:()=>{}, logScale:false
+    minVal:0, maxVal:100, setExternalValue:()=>{}, logScale:false, isDisabled:false
 }

--- a/baby-gru/src/utils/BabyGruUtils.js
+++ b/baby-gru/src/utils/BabyGruUtils.js
@@ -2,6 +2,21 @@
 
 import { v4 as uuidv4 } from 'uuid';
 
+export function sequenceIsSane(sequence) {
+    // If no sequence is present
+    if (!sequence || sequence.length === 0){
+        return false
+    }
+    // If any residue doesn't have rigth attributes
+    if (sequence.some(residue => !Object.keys(residue).includes('resNum') || !Object.keys(residue).includes('resCode'))){
+        return false
+    }
+    // If any of the residues has undefined or Nan as the residue code or residue number
+    if (sequence.some(residue => residue.resNum === null || typeof residue.resNum === 'undefined' || residue.resCode === null || typeof residue.resCode === 'undefined')){
+        return false
+    }
+    return true
+}
 
 export function convertRemToPx(rem) {
     return rem * parseFloat(getComputedStyle(document.documentElement).fontSize);

--- a/baby-gru/src/utils/BabyGruUtils.js
+++ b/baby-gru/src/utils/BabyGruUtils.js
@@ -2,7 +2,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 
-export function sequenceIsSane(sequence) {
+export function sequenceIsValid(sequence) {
     // If no sequence is present
     if (!sequence || sequence.length === 0){
         return false


### PR DESCRIPTION
This update includes the following:

- Fix for the bug where the whole app crashes if the molecule passed to the sequence viewer doesn't have a valid sequence.
- The number of buttons that are shown using icons on the top of the molecule and map cards is set dynamically depending on the available space. Those buttons that don't fit end up in the dropdown menu. This improves the code in  #52 where the layout was set to either "expanded" or "collapsed".
- Created a preferences menu in the navbar. At the moment there are only two options: light/dark mode and expand/collapse molecule and map cards after reading a file.