### PR TITLE
Persistent preferences

### DIFF
--- a/baby-gru/src/App.js
+++ b/baby-gru/src/App.js
@@ -1,13 +1,15 @@
-import logo from './logo.svg';
 import './App.css';
 import { BabyGruContainer } from './components/BabyGruContainer';
+import { PreferencesContextProvider } from "./utils/BabyGruPreferences";
 
 function App() {
   return (
     <div className="App">
-      <BabyGruContainer forwardControls={(controls) => {
-        console.log('Fetched controls', {controls})
-      }} />
+      <PreferencesContextProvider>
+        <BabyGruContainer forwardControls={(controls) => {
+          console.log('Fetched controls', {controls})
+        }}/>
+      </PreferencesContextProvider>
     </div>
   );
 }

--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -1,5 +1,5 @@
-import { useRef, useState, useEffect, createRef, useReducer, useCallback } from 'react';
-import { Navbar, Container, Nav, Tabs, Tab, Accordion, Button, Col, Row, Card, Spinner, Form } from 'react-bootstrap';
+import { useRef, useState, useEffect, createRef, useReducer, useCallback, useContext } from 'react';
+import { Navbar, Container, Nav, Accordion, Button, Col, Row, Spinner, Form } from 'react-bootstrap';
 import Toast from 'react-bootstrap/Toast';
 import ToastContainer from 'react-bootstrap/ToastContainer';
 import { BabyGruDisplayObjects } from './BabyGruDisplayObjects';
@@ -14,6 +14,7 @@ import { BabyGruHistoryMenu } from './BabyGruHistoryMenu';
 import { BabyGruViewMenu } from './BabyGruViewMenu';
 import { BabyGruLigandMenu } from './BabyGruLigandMenu';
 import { BabyGruToolsAccordion } from './BabyGruToolsAccordion'
+import { PreferencesContext } from "../utils/BabyGruPreferences";
 
 
 const initialHistoryState = { commands: [] }
@@ -48,8 +49,6 @@ export const BabyGruContainer = (props) => {
     const graphicsDiv = createRef()
     const navBarRef = useRef()
     const [showSideBar, setShowSideBar] = useState(false)
-    const [darkMode, setDarkMode] = useState(false)
-    const [defaultExpandDisplayCards, setDefaultExpandDisplayCards] = useState(true)
     const [activeMap, setActiveMap] = useState(null)
     const [activeMolecule, setActiveMolecule] = useState(null)
     const [hoveredAtom, setHoveredAtom] = useState({ molecule: null, cid: null })
@@ -76,6 +75,7 @@ export const BabyGruContainer = (props) => {
     const lastHoveredAtom = useRef(null)
     const [showToast, setShowToast] = useState(false)
     const [toastText, setToastText] = useState("")
+    const preferences = useContext(PreferencesContext);
 
     const sideBarWidth = convertViewtoPx(30, windowWidth)
     const innerWindowMarginHeight = convertRemToPx(2.1)
@@ -99,7 +99,7 @@ export const BabyGruContainer = (props) => {
         let head = document.head;
         let style = document.createElement("link");
 
-        if (darkMode) {
+        if (preferences.darkMode) {
             style.href = "/baby-gru/darkly.css"
             setTheme("darkly")
             setBackgroundColor([0., 0., 0., 1.])
@@ -116,7 +116,7 @@ export const BabyGruContainer = (props) => {
         head.appendChild(style);
         return () => { head.removeChild(style); }
 
-    }, [darkMode])
+    }, [preferences.darkMode])
 
 
     useEffect(() => {
@@ -280,17 +280,16 @@ export const BabyGruContainer = (props) => {
     const collectedProps = {
         molecules, changeMolecules, appTitle, setAppTitle, maps, changeMaps, glRef, activeMolecule, setActiveMolecule,
         activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor, sideBarWidth,
-        navBarRef, currentDropdownId, setCurrentDropdownId, darkMode, setDarkMode, defaultExpandDisplayCards,
-        setDefaultExpandDisplayCards, hoveredAtom
+        navBarRef, currentDropdownId, setCurrentDropdownId, hoveredAtom, ...preferences
     }
 
     const accordionToolsItemProps = {
-        molecules, commandCentre, glRef, toolAccordionBodyHeight, sideBarWidth, windowHeight, windowWidth, darkMode, maps, showSideBar,
+        molecules, commandCentre, glRef, toolAccordionBodyHeight, sideBarWidth, windowHeight, windowWidth,maps, showSideBar, ...preferences
     }
 
     return <> <div className={`border ${theme}`} ref={headerRef}>
 
-        <Navbar ref={navBarRef} id='navbar-baby-gru' className={darkMode ? "navbar-dark" : "navbar-light"} style={{ height: '3rem', justifyContent: 'between', margin: '0.5rem', padding: '0.5rem' }}>
+        <Navbar ref={navBarRef} id='navbar-baby-gru' className={preferences.darkMode ? "navbar-dark" : "navbar-light"} style={{ height: '3rem', justifyContent: 'between', margin: '0.5rem', padding: '0.5rem' }}>
             <Navbar.Brand href="#home">{appTitle}</Navbar.Brand>
             <Navbar.Toggle aria-controls="basic-navbar-nav" />
             <Navbar.Collapse id="basic-navbar-nav">
@@ -305,8 +304,8 @@ export const BabyGruContainer = (props) => {
             <Nav className="justify-content-right">
                 {hoveredAtom.cid && <Form.Control style={{ width: "20rem" }} type="text" value={`${hoveredAtom.molecule.name}:${hoveredAtom.cid}`} />}
                 {busy && <Spinner animation="border" style={{ marginRight: '0.5rem' }} />}
-                <Button className="baby-gru-sidebar-button" style={{ height: '100%', backgroundColor: darkMode ? '#222' : 'white', border: 0 }} onClick={() => { setShowSideBar(!showSideBar) }}>
-                    {showSideBar ? <ArrowForwardIosOutlined style={{ color: darkMode ? 'white' : 'black' }} /> : <ArrowBackIosOutlined style={{ color: darkMode ? 'white' : 'black' }} />}
+                <Button className="baby-gru-sidebar-button" style={{ height: '100%', backgroundColor: preferences.darkMode ? '#222' : 'white', border: 0 }} onClick={() => { setShowSideBar(!showSideBar) }}>
+                    {showSideBar ? <ArrowForwardIosOutlined style={{ color: preferences.darkMode ? 'white' : 'black' }} /> : <ArrowBackIosOutlined style={{ color: preferences.darkMode ? 'white' : 'black' }} />}
                 </Button>
             </Nav>
         </Navbar>

--- a/baby-gru/src/utils/BabyGruPreferences.js
+++ b/baby-gru/src/utils/BabyGruPreferences.js
@@ -28,7 +28,7 @@ const PreferencesContextProvider = ({ children }) => {
                 let promises = [localforage.getItem('darkMode'), localforage.getItem('defaultExpandDisplayCards')]
                 let response = await Promise.all(promises)
                 
-                console.log('THIS IS WHAT IS STORED AT THE MOMENT ', response)
+                console.log('Retrieved the following preferences from local storage: ', response)
                 
                 if (!response.every(item => item !== null)) {
                     console.log('Cannot find stored preferences, using defaults')

--- a/baby-gru/src/utils/BabyGruPreferences.js
+++ b/baby-gru/src/utils/BabyGruPreferences.js
@@ -1,54 +1,79 @@
-import React, { createContext, useState, useEffect } from "react";
+import React, { createContext, useState, useEffect, useMemo } from "react";
 import localforage from 'localforage';
+
+const updateStoredPreferences = async (key, value) => {
+    console.log(`Storing ${key}: ${value} preferences in local storage...`)
+    try {
+        await localforage.setItem(key, value)
+    } catch (err) {
+        console.log(err)
+    }
+}
 
 const PreferencesContext = createContext();
 
 const PreferencesContextProvider = ({ children }) => {
     const [darkMode, setDarkMode] = useState(null);
-    const [expandDisplayCards, setExpandDisplayCards] = useState(null);
+    const [defaultExpandDisplayCards, setDefaultExpandDisplayCards] = useState(null);
 
     /**
-     * Hook used after component mounts to retrieve user preferences from local storage
+     * Hook used after component mounts to retrieve user preferences from 
+     * local storage. If no previously stored data is found, default values 
+     * are used.
      */
      useEffect(() => {       
         const fetchStoredPreferences = async () => {
+            console.log('Retrieving stored preferences...')
             try {
-                let promises = [localforage.getItem('darkMode'), localforage.getItem('expandDisplayCards')]
-                let reponse = await Promise.all(promises)
-                setDarkMode(response[0])
-                setExpandDisplayCards(response[1])            
+                let promises = [localforage.getItem('darkMode'), localforage.getItem('defaultExpandDisplayCards')]
+                let response = await Promise.all(promises)
+                
+                console.log('THIS IS WHAT IS STORED AT THE MOMENT ', response)
+                
+                if (!response.every(item => item !== null)) {
+                    console.log('Cannot find stored preferences, using defaults')
+                    setDarkMode(false)
+                    setDefaultExpandDisplayCards(true)            
+                } else {
+                    console.log(`Stored preferences retrieved successfully: ${response}`)
+                    setDarkMode(response[0])
+                    setDefaultExpandDisplayCards(response[1])            
+                }                
+                
             } catch (err) {
                 console.log(err)
                 console.log('Unable to fetch preferences from local storage...')
             }
         }
+        
         localforage.config({
             driver: [localforage.INDEXEDDB, localforage.LOCALSTORAGE],
             name: 'babyGru-localStorage'
-        });
+        });   
 
         fetchStoredPreferences();
         
     }, []);
 
-    /**
-     * Hook to update user preferences in local storage
-     */
-     useEffect(() => {
-        const updateStoredPreferences = async () => {
-            try {
-                let promises = [localforage.setItem('darkMode', darkMode), localforage.setItem('expandDisplayCards', expandDisplayCards)]
-                await Promise.all(promises)      
-            } catch (err) {
-                console.log(err)
-                console.log('Unable to store preferences in local storage...')
-            }
-        }
-        
-        updateStoredPreferences();
-    }, [darkMode, expandDisplayCards]);
+    useMemo(() => {
 
-    const collectedContextValues = {darkMode, setDarkMode, expandDisplayCards, setExpandDisplayCards}
+        if (darkMode === null) {
+            return
+        }
+       
+        updateStoredPreferences('darkMode', darkMode);
+    }, [darkMode]);
+    
+    useMemo(() => {
+
+        if (defaultExpandDisplayCards === null) {
+            return
+        }
+       
+        updateStoredPreferences('defaultExpandDisplayCards', defaultExpandDisplayCards);
+    }, [defaultExpandDisplayCards]);
+
+    const collectedContextValues = {darkMode, setDarkMode, defaultExpandDisplayCards, setDefaultExpandDisplayCards}
 
     return (
       <PreferencesContext.Provider value={collectedContextValues}>


### PR DESCRIPTION
This implements persistent preferences stored in the browser's local storage (uses indexed DB if available otherwise plain local storage). Preferences are passed to the different components in the app using `React.createContext` and `React.useContext`. The way it has been written, I think it should be easy to scale up this context provider with more items if necessary in the future.