### PR TITLE
Webpack - first attempts

### DIFF
--- a/baby-gru/.babelrc
+++ b/baby-gru/.babelrc
@@ -1,0 +1,1 @@
+{"presets":["@babel/env", ["@babel/react", {"runtime": "automatic"}]]}

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "webpack --mode production",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -61,5 +61,19 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.20.2",
+    "@babel/preset-react": "^7.18.6",
+    "@types/node": "^18.11.9",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^9.1.0",
+    "css-loader": "^6.7.2",
+    "html-webpack-plugin": "^5.5.0",
+    "style-loader": "^3.3.1",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.0",
+    "webpack-dev-server": "^4.11.1",
+    "worker-loader": "^3.0.8"
   }
 }

--- a/baby-gru/src/index.html
+++ b/baby-gru/src/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+
+  <script>
+    // See https://github.com/facebook/react/issues/20829#issuecomment-802088260
+    if (!crossOriginIsolated) SharedArrayBuffer = ArrayBuffer;
+  </script>
+
+  <!--Here some imports and actions to make some simple crystallographic logic available to the 
+main UI thread (as opposed to the CootWorker)-->
+  <script>
+    window.onload = () => {
+      createCCP4Module({
+        print(t) { console.log(["output", t]) },
+        printErr(t) { console.log(["output", t]); }
+      })
+        .then(function (CCP4Mod) {
+          window.CCP4Module = CCP4Mod;
+        })
+        .catch((e) => {
+          console.log("CCP4 problem :(");
+          console.log(e);
+        });
+    }
+  </script>
+  <script src="%PUBLIC_URL%/baby-gru/wasm/web_example.js"></script>
+
+  <title>Baby Gru</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+</body>
+
+</html>

--- a/baby-gru/webpack.config.js
+++ b/baby-gru/webpack.config.js
@@ -1,0 +1,73 @@
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const HTMLWebpackPlugin = require('html-webpack-plugin');
+
+const path = require('path');
+
+const paths = {
+  src: path.resolve(__dirname, 'src'),
+  dist: path.resolve(__dirname, 'dist'),
+  public: path.resolve(__dirname, 'public', 'baby-gru'),
+  pixmaps: path.resolve(__dirname, 'public', 'baby-gru', 'pixmaps'),
+}
+
+module.exports = {
+  plugins:[
+   
+    new HTMLWebpackPlugin({
+      filename: 'index.html',
+      template: path.join(__dirname, '/src/index.html'),
+      favicon: path.join(__dirname, 'public', 'favicon.ico')
+    }),
+    
+    new MiniCssExtractPlugin({
+      filename: '[name][contenthash].css',
+      chunkFilename: '[id].css',
+      ignoreOrder: false,
+    }),
+
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: paths.public,
+          to: paths.dist + '/baby-gru/',
+          toType: 'dir',
+        },
+      ],
+    }),
+],
+  entry: path.join(paths.src, 'index.js'),
+  mode: 'production',
+  cache: false,
+  relativeUrls: true,
+  output: {
+    clean: true,
+    filename: '[name].js',
+    path: paths.dist,
+    publicPath: paths.dist
+  },
+    module:{
+        rules:[
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                loader: 'babel-loader',
+            },
+            {
+              test: /\.(?:ico|gif|png|jpg|jpeg|svg|xpm)$/,
+              loader: 'file-loader',
+              type: 'asset/resource',
+            },
+            {
+                test: /\.css$/,
+                sideEffects: true,
+                use: [ MiniCssExtractPlugin.loader, 'css-loader'],
+            }
+        ]
+    },
+    resolve: {
+        fallback: {
+          fs: false
+        }
+      }
+}


### PR DESCRIPTION
This is slowly reaching the limit of my abilities so I'm putting this here in case someone has any ideas. At the moment, the static build can be created using `npm run build`. That will use webpack to create the static html and js files in a `dist/` folder. You will need to install the new dev dependencies listed in `package.json` for this to work. At the moment there are three (separate?) problems:

1. **Assets are not loaded correctly.** Despite all my efforts I seem to be unable to tell webpack to include the files in pixmaps in the bundle. Even if I copy these files using `CopyWebpackPlugin` into the `dist/` folder, the code still can't find the files.
2. **CSS style sheets not loaded correctly.** Something that seems to be working properly is that the CSS code is bundled together correctly using `MiniCssExtractPlugin`. The problem is the bundled js file seems to ignore it / be unable to import it / find it.
3. **Web worker security issues.** If you open the file in firefox, you'll be presented with the following error message:
```
Security Error: Content at file:///home/filo/VSCodeProjects/ccp4_wasm/baby-gru/dist/index.html may not load data from file:///baby-gru/CootWorker.js. 
```
In Chrome the page fails to load and the message is: 
```
DOMException: Failed to construct 'Worker': Script at 'file:///baby-gru/CootWorker.js' cannot be accessed from origin 'null'.
```
After few google-searches and dead-ends I think this is related to some security issues (modern browsers won't let you load workers when running a scripts from the local filesystem). There are some stackoverflow posts describing this, for example: https://stackoverflow.com/questions/58099138/getting-failed-to-construct-worker-with-js-worker-file-located-on-other-domain.
4. **Cannot find `createCCP4Module` in `index.html`**. This issue was already briefly described in slack. At the moment the browser complains that `Uncaught (in promise) TypeError: window.CCP4Module is undefined`. I know the problem is once again the browser can't find the right file (in this case `web_example.js`). The interesting thing is, if I modify `index.html` to point directly at this file using the full path in my machine (so not a real solution, just testing), the error is substituted with:
```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at file:///home/filo/VSCodeProjects/ccp4_wasm/baby-gru/dist/baby-gru/wasm/web_example.wasm. (Reason: CORS request not http).
```

Which indicates that even if I fixed the file to point at the right file we would still have some CORS security issues.