### PR TITLE
Fix minor bug and minor code refactor

### DIFF
--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -12,14 +12,14 @@ export const BabyGruMapCard = (props) => {
     const [mapContourLevel, setMapContourLevel] = useState(props.initialContour)
     const [mapLitLines, setMapLitLines] = useState(props.initialMapLitLines)    
     const [isCollapsed, setIsCollapsed] = useState(!props.defaultExpandDisplayCards);
-    const [currentName, setCurrentName] = useState(props.map.mapName);
+    const [currentName, setCurrentName] = useState(props.map.name);
     const nextOrigin = createRef([])
     const busyContouring = createRef(false)
     const [popoverIsShown, setPopoverIsShown] = useState(false)
 
     const handleDownload = async () => {
         let response = await props.map.getMap()
-        doDownload([response.data.result.mapData], `${props.map.mapName.replace('.mtz', '.map')}`)
+        doDownload([response.data.result.mapData], `${props.map.name.replace('.mtz', '.map')}`)
         props.setCurrentDropdownMolNo(-1)
     }
 
@@ -86,7 +86,14 @@ export const BabyGruMapCard = (props) => {
         })
 
         compressedButtons.push((
-            <BabyGruDeleteDisplayObjectMenuItem setPopoverIsShown={setPopoverIsShown} glRef={props.glRef} changeItemList={props.changeMaps} itemList={props.maps} item={props.map}/>
+            <BabyGruDeleteDisplayObjectMenuItem 
+                setPopoverIsShown={setPopoverIsShown} 
+                glRef={props.glRef} 
+                changeItemList={props.changeMaps}
+                 itemList={props.maps} 
+                 item={props.map}
+                  setActiveMap={props.setActiveMap}
+                   activeMap={props.activeMap}/>
         ))
         
         return  <Fragment>
@@ -156,7 +163,7 @@ export const BabyGruMapCard = (props) => {
         if (currentName == "") {
             return
         }
-        props.map.mapName = currentName
+        props.map.name = currentName
 
     }, [currentName]);
 
@@ -198,7 +205,7 @@ export const BabyGruMapCard = (props) => {
         <Card.Header>
             <Row className='align-items-center'>
             <Col style={{display:'flex', justifyContent:'left'}}>
-                    {`#${props.map.molNo} Map ${props.map.mapName}`}
+                    {`#${props.map.molNo} Map ${props.map.name}`}
             </Col>
             <Col style={{display:'flex', justifyContent:'right'}}>
                 {getButtonBar(props.sideBarWidth)}

--- a/baby-gru/src/components/BabyGruMapSelect.js
+++ b/baby-gru/src/components/BabyGruMapSelect.js
@@ -17,7 +17,7 @@ export const BabyGruMapSelect = forwardRef((props, selectRef) => {
                 if(props.onlyDifferenceMaps && !map.isDifference){
                     return
                 }
-                mapOptions.push(<option key={map.molNo} value={map.molNo}>{map.molNo}: {map.mapName}</option>)
+                mapOptions.push(<option key={map.molNo} value={map.molNo}>{map.molNo}: {map.name}</option>)
             })
         }
 

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -170,6 +170,9 @@ export const BabyGruDeleteDisplayObjectMenuItem = (props) => {
         props.changeItemList({ action: 'Remove', item: props.item })
         props.item.delete(props.glRef);
         props.setPopoverIsShown(false)
+        if(props.item.type === "map" && props.activeMap.molNo === props.item.molNo) {
+            props.setActiveMap(null)
+        }
     }
 
     return <BabyGruMenuItem
@@ -178,7 +181,7 @@ export const BabyGruDeleteDisplayObjectMenuItem = (props) => {
         buttonText="Delete"
         popoverPlacement='left'
         popoverContent={panelContent}
-        menuItemText={props.item.name ? "Delete molecule" : "Delete map"}
+        menuItemText={props.item.type === 'molecule' ? "Delete molecule" : "Delete map"}
         onCompleted={onCompleted}
         setPopoverIsShown={props.setPopoverIsShown}
     />
@@ -203,7 +206,7 @@ export const BabyGruRenameDisplayObjectMenuItem = (props) => {
         if (newName == "") {
             return
         }
-        props.item.name ? props.item.name = newName : props.item.mapName = newName
+        props.item.name ? props.item.name = newName : props.item.name = newName
         props.setCurrentName(newName)
         props.setPopoverIsShown(false)
     }

--- a/baby-gru/src/utils/BabyGruMap.js
+++ b/baby-gru/src/utils/BabyGruMap.js
@@ -2,6 +2,7 @@ import { readDataFile } from "./BabyGruUtils"
 import { readMapFromArrayBuffer, mapToMapGrid } from '../WebGL/mgWebGLReadMap';
 
 export function BabyGruMap(commandCentre) {
+    this.type = 'map'
     this.commandCentre = commandCentre
     this.contourLevel = 0.5
     this.mapColour = [0.3, 0.3, 1.0, 1.0]
@@ -25,7 +26,7 @@ BabyGruMap.prototype.delete = async function (glRef) {
 }
 
 
-BabyGruMap.prototype.loadToCootFromURL = function (url, mapName, selectedColumns) {
+BabyGruMap.prototype.loadToCootFromURL = function (url, name, selectedColumns) {
     const $this = this
     console.log('Off to fetch url', url)
     //Remember to change this to an appropriate URL for downloads in produciton, and to deal with the consequent CORS headache
@@ -34,20 +35,20 @@ BabyGruMap.prototype.loadToCootFromURL = function (url, mapName, selectedColumns
             return response.blob()
         }).then(reflectionData => reflectionData.arrayBuffer())
         .then(arrayBuffer => {
-            return $this.loadToCootFromData(new Uint8Array(arrayBuffer), mapName, selectedColumns)
+            return $this.loadToCootFromData(new Uint8Array(arrayBuffer), name, selectedColumns)
         })
         .catch((err) => { console.log(err) })
 }
 
 
-BabyGruMap.prototype.loadToCootFromData = function (data, mapName, selectedColumns) {
+BabyGruMap.prototype.loadToCootFromData = function (data, name, selectedColumns) {
     const $this = this
-    $this.mapName = mapName
+    $this.name = name
     return new Promise((resolve, reject) => {
         return this.commandCentre.current.cootCommand({
             returnType: "status",
             command: "shim_read_mtz",
-            commandArgs: [data, mapName, selectedColumns]
+            commandArgs: [data, name, selectedColumns]
         })
             .then(reply => {
                 $this.molNo = reply.data.result.result
@@ -68,14 +69,14 @@ BabyGruMap.prototype.loadToCootFromFile = function (source, selectedColumns) {
         })
 }
 
-BabyGruMap.prototype.loadToCootFromMapData = function (data, mapName, isDiffMap) {
+BabyGruMap.prototype.loadToCootFromMapData = function (data, name, isDiffMap) {
     const $this = this
-    $this.mapName = mapName
+    $this.name = name
     return new Promise((resolve, reject) => {
         return this.commandCentre.current.cootCommand({
             returnType: "status",
             command: "shim_read_ccp4_map",
-            commandArgs: [data, mapName, isDiffMap]
+            commandArgs: [data, name, isDiffMap]
         })
             .then(reply => {
                 $this.molNo = reply.data.result.result

--- a/baby-gru/src/utils/BabyGruMolecule.js
+++ b/baby-gru/src/utils/BabyGruMolecule.js
@@ -12,6 +12,7 @@ import { quatToMat4, quat4Inverse } from '../WebGL/quatToMat4.js';
 import * as vec3 from 'gl-matrix/vec3';
 
 export function BabyGruMolecule(commandCentre) {
+    this.type = 'molecule'
     this.commandCentre = commandCentre
     this.enerLib = new EnerLib()
     this.HBondsAssigned = false


### PR DESCRIPTION
After this update:
- Both `BabyGruMap` and `BabyGruMolecule` store their name in a property named `name` (previously maps had their attribute name `mapName`). This simplifies some code in some menu items. 
- To tell the difference between maps and molecules in components that can accept both as input, a new attribute `type` has been added. 
- Also a bug has been fixed: if the active map was deleted the user would still be able to use buttons in the bar at the bottom that require and active map.