### PR TITLE
Store shortcuts in preference context manager

### DIFF
--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -164,8 +164,8 @@ export const BabyGruContainer = (props) => {
 
     //Make this so that the keyPress returns true or false, depending on whether mgWebGL is to continue processing event
     const onKeyPress = useCallback(event => {
-        return babyGruKeyPress(event, collectedProps)
-    }, [molecules, activeMolecule, activeMap, hoveredAtom])
+        return babyGruKeyPress(event, collectedProps, JSON.parse(preferences.shortCuts))
+    }, [molecules, activeMolecule, activeMap, hoveredAtom, preferences])
 
     useEffect(() => {
         if (hoveredAtom && hoveredAtom.molecule && hoveredAtom.cid) {

--- a/baby-gru/src/components/BabyGruKeyboardAccelerators.js
+++ b/baby-gru/src/components/BabyGruKeyboardAccelerators.js
@@ -1,5 +1,4 @@
 import { List, ListItem } from "@mui/material"
-import { active } from "d3"
 import { cidToSpec } from "../utils/BabyGruUtils"
 
 const apresEdit = (molecule, glRef, setHoveredAtom) => {

--- a/baby-gru/src/utils/BabyGruPreferences.js
+++ b/baby-gru/src/utils/BabyGruPreferences.js
@@ -15,11 +15,54 @@ const PreferencesContext = createContext();
 const PreferencesContextProvider = ({ children }) => {
     const [darkMode, setDarkMode] = useState(null);
     const [defaultExpandDisplayCards, setDefaultExpandDisplayCards] = useState(null);
+    const [shortCuts, setShortCuts] = useState(null);
     const defaultValues = {
         darkMode: false, 
         defaultExpandDisplayCards: true,
-        
-    }
+        shortCuts: {
+            "sphere_refine": {
+                modifiers: ["shiftKey"],
+                keyPress: "r",
+                label: "Refine sphere"
+            },
+            "flip_peptide": {
+                modifiers: ["shiftKey"],
+                keyPress: "q",
+                label: "Flip peptide"
+            },
+            "triple_refine": {
+                modifiers: ["shiftKey"],
+                keyPress: "h",
+                label: "Refine triplet"
+            },
+            "auto_fit_rotamer": {
+                modifiers: ["shiftKey"],
+                keyPress: "j",
+                label: "Autofit rotamer"
+            },
+            "add_terminal_residue": {
+                modifiers: ["shiftKey"],
+                keyPress: "y",
+                label: "Add terminal residue"
+            },
+            "delete_residue": {
+                modifiers: ["shiftKey"],
+                keyPress: "d",
+                label: "Delete residue"
+            },
+            "eigen_flip": {
+                modifiers: ["shiftKey"],
+                keyPress: "e",
+                label: "Eigen flip ligand"
+            },
+            "show_shortcuts": {
+                modifiers: ["metaKey"],
+                keyPress: "Meta",
+                label: "Show shortcuts"
+            }
+        }
+    }  
+
 
     /**
      * Hook used after component mounts to retrieve user preferences from 
@@ -30,19 +73,21 @@ const PreferencesContextProvider = ({ children }) => {
         const fetchStoredPreferences = async () => {
             console.log('Retrieving stored preferences...')
             try {
-                let promises = [localforage.getItem('darkMode'), localforage.getItem('defaultExpandDisplayCards')]
+                let promises = [localforage.getItem('darkMode'), localforage.getItem('defaultExpandDisplayCards'), localforage.getItem('shortCuts')]
                 let response = await Promise.all(promises)
                 
                 console.log('Retrieved the following preferences from local storage: ', response)
                 
-                if (!response.every(item => item !== null)) {
+                if (!response.every(item => item !== null) || response.length < Object.keys(defaultValues).length) {
                     console.log('Cannot find stored preferences, using defaults')
                     setDarkMode(defaultValues.darkMode)
                     setDefaultExpandDisplayCards(defaultValues.defaultExpandDisplayCards)            
+                    setShortCuts(JSON.stringify(defaultValues.shortCuts))            
                 } else {
                     console.log(`Stored preferences retrieved successfully: ${response}`)
                     setDarkMode(response[0])
-                    setDefaultExpandDisplayCards(response[1])            
+                    setDefaultExpandDisplayCards(response[1])
+                    setShortCuts(response[2])
                 }                
                 
             } catch (err) {
@@ -78,7 +123,16 @@ const PreferencesContextProvider = ({ children }) => {
         updateStoredPreferences('defaultExpandDisplayCards', defaultExpandDisplayCards);
     }, [defaultExpandDisplayCards]);
 
-    const collectedContextValues = {darkMode, setDarkMode, defaultExpandDisplayCards, setDefaultExpandDisplayCards}
+    useMemo(() => {
+
+        if (shortCuts === null) {
+            return
+        }
+       
+        updateStoredPreferences('shortCuts', shortCuts);
+    }, [shortCuts]);
+
+    const collectedContextValues = {darkMode, setDarkMode, defaultExpandDisplayCards, setDefaultExpandDisplayCards, shortCuts, setShortCuts}
 
     return (
       <PreferencesContext.Provider value={collectedContextValues}>


### PR DESCRIPTION
This includes the first steps towards customizable shortcuts. After this update shortcut mappings are stored in the browser storage using the preferences context manager. Now it should be as easy as creating a UI interface to let users choose their own shortcuts, which will persist even after the tab is closed.