### PR TITLE
Unify keyboard accelerators

### DIFF
--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -314,6 +314,7 @@ export const BabyGruContainer = (props) => {
                             atomLabelDepthMode={preferences.atomLabelDepthMode}
                             onAtomHovered={onAtomHovered}
                             onKeyPress={onKeyPress}
+                            preferences={preferences}
                         />
                     </div>
                     <div id='button-bar-baby-gru'

--- a/baby-gru/src/components/BabyGruKeyboardAccelerators.js
+++ b/baby-gru/src/components/BabyGruKeyboardAccelerators.js
@@ -179,7 +179,6 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
     if (action === 'clear_labels') {
         glRef.current.clickedAtoms = [];
         glRef.current.drawScene();
-
     }
 
     if (action === 'move_up') {

--- a/baby-gru/src/components/BabyGruKeyboardAccelerators.js
+++ b/baby-gru/src/components/BabyGruKeyboardAccelerators.js
@@ -74,7 +74,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         return false
     }
 
-    if (action === 'triple_refine' && activeMap && hoveredAtom.molecule) {
+    else if (action === 'triple_refine' && activeMap && hoveredAtom.molecule) {
         const chosenAtom = cidToSpec(hoveredAtom.cid)
         const commandArgs = [
             `${hoveredAtom.molecule.molNo}`,
@@ -91,7 +91,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         return false
     }
 
-    if (action === 'auto_fit_rotamer' && activeMap && hoveredAtom.molecule) {
+    else if (action === 'auto_fit_rotamer' && activeMap && hoveredAtom.molecule) {
         const chosenAtom = cidToSpec(hoveredAtom.cid)
         const commandArgs = [
             hoveredAtom.molecule.molNo,
@@ -111,7 +111,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         return false
     }
 
-    if (action === 'add_terminal_residue' && activeMap && hoveredAtom.molecule) {
+    else if (action === 'add_terminal_residue' && activeMap && hoveredAtom.molecule) {
         const chosenAtom = cidToSpec(hoveredAtom.cid)
         const commandArgs = [
             hoveredAtom.molecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`]
@@ -126,7 +126,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         return false
     }
     
-    if (action === 'delete_residue' && hoveredAtom.molecule) {
+    else if (action === 'delete_residue' && hoveredAtom.molecule) {
         const chosenAtom = cidToSpec(hoveredAtom.cid)
         const commandArgs = [
             hoveredAtom.molecule.molNo,
@@ -144,7 +144,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         return false
     }
     
-    if (action === 'eigen_flip'  && hoveredAtom.molecule) {
+    else if (action === 'eigen_flip'  && hoveredAtom.molecule) {
         const chosenAtom = cidToSpec(hoveredAtom.cid)
         const commandArgs = [hoveredAtom.molecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`]
         commandCentre.current.cootCommand({
@@ -158,7 +158,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         return false
     }
 
-    if (action === 'go_to_blob' && activeMap) {
+    else if (action === 'go_to_blob' && activeMap) {
         
         const frontAndBack = glRef.current.getFrontAndBackPos(event);
         const goToBlobEvent = {
@@ -180,12 +180,12 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         })
     }
 
-    if (action === 'clear_labels') {
+    else if (action === 'clear_labels') {
         glRef.current.clickedAtoms = [];
         glRef.current.drawScene();
     }
 
-    if (action === 'move_up') {
+    else if (action === 'move_up') {
         const invQuat = quat4.create();
         quat4Inverse(glRef.current.myQuat, invQuat);
         const theMatrix = quatToMat4(invQuat);
@@ -200,7 +200,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.reContourMaps();
     }
 
-    if (action === 'move_down') {
+    else if (action === 'move_down') {
         const invQuat = quat4.create();
         quat4Inverse(glRef.current.myQuat, invQuat);
         const theMatrix = quatToMat4(invQuat);
@@ -215,7 +215,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.reContourMaps();
     }
 
-    if (action === 'move_left') {
+    else if (action === 'move_left') {
         const invQuat = quat4.create();
         quat4Inverse(glRef.current.myQuat, invQuat);
         const theMatrix = quatToMat4(invQuat);
@@ -230,7 +230,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.reContourMaps();
     }
 
-    if (action === 'move_right') {
+    else if (action === 'move_right') {
         const invQuat = quat4.create();
         quat4Inverse(glRef.current.myQuat, invQuat);
         const theMatrix = quatToMat4(invQuat);
@@ -245,7 +245,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.reContourMaps();
     }
 
-    if (action === 'restore_scene') {
+    else if (action === 'restore_scene') {
         glRef.current.myQuat = quat4.create()
         quat4.set(glRef.current.myQuat, 0, 0, 0, -1)
         glRef.current.setZoom(1.0)
@@ -253,7 +253,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.drawScene()
     }
 
-    if (action === 'take_screenshot') {
+    else if (action === 'take_screenshot') {
         const oldOrigin = [glRef.current.origin[0], glRef.current.origin[1], glRef.current.origin[2]];
 
         // Getting up and right for doing tiling (in future?)

--- a/baby-gru/src/components/BabyGruKeyboardAccelerators.js
+++ b/baby-gru/src/components/BabyGruKeyboardAccelerators.js
@@ -1,5 +1,9 @@
 import { List, ListItem } from "@mui/material"
 import { cidToSpec } from "../utils/BabyGruUtils"
+import * as vec3 from 'gl-matrix/vec3';
+import * as quat4 from 'gl-matrix/quat';
+import { quatToMat4, quat4Inverse } from '../WebGL/quatToMat4.js';
+import { getDeviceScale, vec3Create } from '../WebGL/mgWebGL';
 
 const apresEdit = (molecule, glRef, setHoveredAtom) => {
     molecule.setAtomsDirty(true)
@@ -182,27 +186,154 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
     }
 
     if (action === 'move_up') {
-        glRef.current.moveUp(glRef.current)
+        const invQuat = quat4.create();
+        quat4Inverse(glRef.current.myQuat, invQuat);
+        const theMatrix = quatToMat4(invQuat);
+        const yshift = vec3Create([0, 4. / getDeviceScale(), 0]);
+        vec3.transformMat4(yshift, yshift, theMatrix);
+        glRef.current.origin[0] += yshift[0] / 8. * glRef.current.zoom;
+        glRef.current.origin[1] += yshift[1] / 8. * glRef.current.zoom;
+        glRef.current.origin[2] += yshift[2] / 8. * glRef.current.zoom;
+        const originChangeEvent = new CustomEvent("originChange", { "detail": glRef.current.origin });
+        document.dispatchEvent(originChangeEvent);
+        glRef.current.drawSceneDirty();
+        glRef.current.reContourMaps();
     }
 
     if (action === 'move_down') {
-        glRef.current.moveDown(glRef.current)
+        const invQuat = quat4.create();
+        quat4Inverse(glRef.current.myQuat, invQuat);
+        const theMatrix = quatToMat4(invQuat);
+        const yshift = vec3Create([0, -4. / getDeviceScale(), 0]);
+        vec3.transformMat4(yshift, yshift, theMatrix);
+        glRef.current.origin[0] += yshift[0] / 8. * glRef.current.zoom;
+        glRef.current.origin[1] += yshift[1] / 8. * glRef.current.zoom;
+        glRef.current.origin[2] += yshift[2] / 8. * glRef.current.zoom;
+        const originChangeEvent = new CustomEvent("originChange", { "detail": glRef.current.origin });
+        document.dispatchEvent(originChangeEvent);
+        glRef.current.drawSceneDirty();
+        glRef.current.reContourMaps();
     }
 
     if (action === 'move_left') {
-        glRef.current.moveLeft(glRef.current)
+        const invQuat = quat4.create();
+        quat4Inverse(glRef.current.myQuat, invQuat);
+        const theMatrix = quatToMat4(invQuat);
+        const xshift = vec3Create([-4. / getDeviceScale(), 0, 0]);
+        vec3.transformMat4(xshift, xshift, theMatrix);
+        glRef.current.origin[0] += xshift[0] / 8. * glRef.current.zoom;
+        glRef.current.origin[1] += xshift[1] / 8. * glRef.current.zoom;
+        glRef.current.origin[2] += xshift[2] / 8. * glRef.current.zoom;
+        const originChangeEvent = new CustomEvent("originChange", { "detail": glRef.current.origin });
+        document.dispatchEvent(originChangeEvent);
+        glRef.current.drawSceneDirty();
+        glRef.current.reContourMaps();
     }
 
     if (action === 'move_right') {
-        glRef.current.moveRight(glRef.current)
+        const invQuat = quat4.create();
+        quat4Inverse(glRef.current.myQuat, invQuat);
+        const theMatrix = quatToMat4(invQuat);
+        const xshift = vec3Create([4. / getDeviceScale(), 0, 0]);
+        vec3.transformMat4(xshift, xshift, theMatrix);
+        glRef.current.origin[0] += xshift[0] / 8. * glRef.current.zoom;
+        glRef.current.origin[1] += xshift[1] / 8. * glRef.current.zoom;
+        glRef.current.origin[2] += xshift[2] / 8. * glRef.current.zoom;
+        const originChangeEvent = new CustomEvent("originChange", { "detail": glRef.current.origin });
+        document.dispatchEvent(originChangeEvent);
+        glRef.current.drawSceneDirty();
+        glRef.current.reContourMaps();
     }
 
     if (action === 'restore_scene') {
-        glRef.current.restoreScene(glRef.current)
+        glRef.current.myQuat = quat4.create()
+        quat4.set(glRef.current.myQuat, 0, 0, 0, -1)
+        glRef.current.setZoom(1.0)
+        glRef.current.clickedAtoms = []
+        glRef.current.drawScene()
     }
 
     if (action === 'take_screenshot') {
-        glRef.current.takeScreenShot(event, glRef.current)
+        const oldOrigin = [glRef.current.origin[0], glRef.current.origin[1], glRef.current.origin[2]];
+
+        // Getting up and right for doing tiling (in future?)
+        const invQuat = quat4.create();
+        quat4Inverse(glRef.current.myQuat, invQuat);
+
+        const invMat = quatToMat4(invQuat);
+
+        const right = vec3.create();
+        vec3.set(right, 1.0, 0.0, 0.0);
+        const up = vec3.create();
+        vec3.set(up, 0.0, 1.0, 0.0);
+
+        vec3.transformMat4(up, up, invMat);
+        vec3.transformMat4(right, right, invMat);
+
+        console.log(right);
+        console.log(up);
+        console.log(glRef.current.zoom);
+
+        const mag = 1;
+
+        const ncells_x = mag;
+        const ncells_y = mag;
+
+        const saveCanvas = document.createElement("canvas");
+        saveCanvas.width = glRef.current.canvas.width * ncells_x;
+        saveCanvas.height = glRef.current.canvas.height * ncells_y;
+        const ctx = saveCanvas.getContext("2d");
+
+        let newZoom = glRef.current.zoom / ncells_x
+        glRef.current.setZoom(newZoom)
+
+        let jj = 0;
+        for (let j = Math.floor(-ncells_y / 2); j < Math.floor(ncells_y / 2); j++) {
+            let ii = 0;
+            for (let i = Math.floor(-ncells_x / 2); i < Math.floor(ncells_x / 2); i++) {
+                const x_off = (2.0 * i + 1 + ncells_x % 2);
+                const y_off = (2.0 * j + 1 + ncells_y % 2);
+
+                glRef.current.origin = [oldOrigin[0], oldOrigin[1], oldOrigin[2]];
+                glRef.current.origin[0] += glRef.current.zoom * right[0] * 24.0 * x_off + glRef.current.zoom * up[0] * 24.0 * y_off;
+                glRef.current.origin[1] += glRef.current.zoom * right[1] * 24.0 * x_off + glRef.current.zoom * up[1] * 24.0 * y_off;
+                glRef.current.origin[2] += glRef.current.zoom * right[2] * 24.0 * x_off + glRef.current.zoom * up[2] * 24.0 * y_off;
+
+
+                glRef.current.save_pixel_data = true;
+                glRef.current.drawScene();
+                const pixels = glRef.current.pixel_data;
+
+                const imgData = ctx.createImageData(glRef.current.canvas.width, glRef.current.canvas.height);
+                const data = imgData.data;
+
+                for (let pixi = 0; pixi < glRef.current.canvas.height; pixi++) {
+                    for (let pixj = 0; pixj < glRef.current.canvas.width * 4; pixj++) {
+                        data[(glRef.current.canvas.height - pixi - 1) * glRef.current.canvas.width * 4 + pixj] = pixels[pixi * glRef.current.canvas.width * 4 + pixj];
+                    }
+                }
+                ctx.putImageData(imgData, (ncells_x - ii - 1) * glRef.current.canvas.width, jj * glRef.current.canvas.height);
+                ii++;
+            }
+            jj++;
+        }
+
+        newZoom = glRef.current.zoom * ncells_x
+        glRef.current.setZoom(newZoom)
+
+        glRef.current.origin = [oldOrigin[0], oldOrigin[1], oldOrigin[2]];
+        glRef.current.save_pixel_data = false;
+        glRef.current.drawScene();
+
+        let link = document.getElementById('download_image_link');
+        if(!link){
+            link = document.createElement('a');
+            link.id = 'download_image_link';
+            link.download = 'moorhen.png';
+            document.body.appendChild(link);
+        }
+        link.href = saveCanvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
+        link.click();
     }
 
     else if (action === 'show_shortcuts') {

--- a/baby-gru/src/components/BabyGruKeyboardAccelerators.js
+++ b/baby-gru/src/components/BabyGruKeyboardAccelerators.js
@@ -154,6 +154,58 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         return false
     }
 
+    if (action === 'go_to_blob' && activeMap) {
+        
+        const frontAndBack = glRef.current.getFrontAndBackPos(event);
+        const goToBlobEvent = {
+                back: [frontAndBack[0][0], frontAndBack[0][1], frontAndBack[0][2]],
+                front: [frontAndBack[1][0], frontAndBack[1][1], frontAndBack[1][2]],
+                windowX: frontAndBack[2],
+                windowY: frontAndBack[3],
+        };
+
+        commandCentre.current.cootCommand({
+            returnType: "float_array",
+            command: "go_to_blob_array",
+            commandArgs: [goToBlobEvent.front[0], goToBlobEvent.front[1], goToBlobEvent.front[2], goToBlobEvent.back[0], goToBlobEvent.back[1], goToBlobEvent.back[2], 0.5]
+        }).then(response => {
+            let newOrigin = response.data.result.result;
+            if (newOrigin.length === 3) {
+                glRef.current.setOrigin([-newOrigin[0], -newOrigin[1], -newOrigin[2]])
+            }
+        })
+    }
+
+    if (action === 'move_up') {
+        glRef.current.moveUp(glRef.current)
+    }
+
+    if (action === 'move_down') {
+        glRef.current.moveDown(glRef.current)
+    }
+
+    if (action === 'move_left') {
+        glRef.current.moveLeft(glRef.current)
+    }
+
+    if (action === 'move_right') {
+        glRef.current.moveRight(glRef.current)
+    }
+
+    if (action === 'restore_scene') {
+        glRef.current.restoreScene(glRef.current)
+    }
+
+    if (action === 'take_screenshot') {
+        glRef.current.takeScreenShot(event, glRef.current)
+    }
+
+    if (action === 'clear_labels') {
+        glRef.current.clickedAtoms = [];
+        glRef.current.drawScene();
+
+    }
+
     else if (action === 'show_shortcuts') {
         setToastContent(<h4><List>
             {Object.keys(shortCuts).map(key => {
@@ -162,11 +214,13 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
                 if (shortCuts[key].modifiers.includes('ctrlKey')) modifiers.push("<Ctrl>")
                 if (shortCuts[key].modifiers.includes('metaKey')) modifiers.push("<Meta>")
                 if (shortCuts[key].modifiers.includes('altKey')) modifiers.push("<Alt>")                
-                return <ListItem>{`${modifiers.join("-")} ${shortCuts[key].label}`}</ListItem>
+                return <ListItem>{`${modifiers.join("-")} ${shortCuts[key].keyPress} ${shortCuts[key].label}`}</ListItem>
             })}
         </List></h4>)
         setShowToast(true)
         return false
     }
+
     return true
+
 }

--- a/baby-gru/src/components/BabyGruKeyboardAccelerators.js
+++ b/baby-gru/src/components/BabyGruKeyboardAccelerators.js
@@ -176,6 +176,12 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         })
     }
 
+    if (action === 'clear_labels') {
+        glRef.current.clickedAtoms = [];
+        glRef.current.drawScene();
+
+    }
+
     if (action === 'move_up') {
         glRef.current.moveUp(glRef.current)
     }
@@ -198,12 +204,6 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
 
     if (action === 'take_screenshot') {
         glRef.current.takeScreenShot(event, glRef.current)
-    }
-
-    if (action === 'clear_labels') {
-        glRef.current.clickedAtoms = [];
-        glRef.current.drawScene();
-
     }
 
     else if (action === 'show_shortcuts') {

--- a/baby-gru/src/components/BabyGruWebMG.js
+++ b/baby-gru/src/components/BabyGruWebMG.js
@@ -17,28 +17,6 @@ export const BabyGruWebMG = forwardRef((props, glRef) => {
         setClipFogByZoom()
     })
 
-    const handleKeyPressWithMousePosition = useCallback(e => {
-        if (e.detail.key === "G") {
-            props.commandCentre.current.cootCommand({
-                returnType: "float_array",
-                command: "go_to_blob_array",
-                commandArgs: [e.detail.front[0], e.detail.front[1], e.detail.front[2], e.detail.back[0], e.detail.back[1], e.detail.back[2], 0.5]
-            }).then(response => {
-                let newOrigin = response.data.result.result;
-                if (newOrigin.length === 3) {
-                    glRef.current.setOrigin([-newOrigin[0], -newOrigin[1], -newOrigin[2]])
-                }
-            })
-        }
-    })
-
-    useEffect(() => {
-        document.addEventListener("keyPressWithMousePosition", handleKeyPressWithMousePosition);
-        return () => {
-            document.removeEventListener("keyPressWithMousePosition", handleKeyPressWithMousePosition);
-        };
-    }, [handleKeyPressWithMousePosition]);
-
     useEffect(() => {
         document.addEventListener("zoomChanged", handleZoomChanged);
         return () => {
@@ -109,7 +87,8 @@ export const BabyGruWebMG = forwardRef((props, glRef) => {
         dataChanged={(d) => { console.log(d) }}
         onAtomHovered={props.onAtomHovered}
         onKeyPress={props.onKeyPress}
-        messageChanged={() => { }} />
+        messageChanged={() => { }}
+        keyboardAccelerators={JSON.parse(props.preferences.shortCuts)}/>
 });
 
 

--- a/baby-gru/src/utils/BabyGruPreferences.js
+++ b/baby-gru/src/utils/BabyGruPreferences.js
@@ -107,7 +107,6 @@ const PreferencesContextProvider = ({ children }) => {
                 keyPress: "m",
                 label: "Label an atom on click"
             }
-
         }
     }  
 

--- a/baby-gru/src/utils/BabyGruPreferences.js
+++ b/baby-gru/src/utils/BabyGruPreferences.js
@@ -61,7 +61,53 @@ const PreferencesContextProvider = ({ children }) => {
                 modifiers: ["metaKey"],
                 keyPress: "Meta",
                 label: "Show shortcuts"
+            },
+            "restore_scene": {
+                modifiers: [],
+                keyPress: "r",
+                label: "Restore scene"
+            },
+            "clear_labels": {
+                modifiers: [],
+                keyPress: "c",
+                label: "Clear labels"
+            },
+            "move_up": {
+                modifiers: [],
+                keyPress: "arrowup",
+                label: "Move model up"
+            },
+            "move_down": {
+                modifiers: [],
+                keyPress: "arrowdown",
+                label: "Move model down"
+            },
+            "move_left": {
+                modifiers: [],
+                keyPress: "arrowleft",
+                label: "Move model left"
+            },
+            "move_right": {
+                modifiers: [],
+                keyPress: "arrowright",
+                label: "Move model right"
+            },
+            "go_to_blob": {
+                modifiers: [],
+                keyPress: "g",
+                label: "Go to blob"
+            },
+            "take_screenshot": {
+                modifiers: [],
+                keyPress: "s",
+                label: "Take a screenshot"
+            },
+            "label_atom": {
+                modifiers: [],
+                keyPress: "m",
+                label: "Label an atom on click"
             }
+
         }
     }  
 

--- a/react-app/src/mgWebGL.js
+++ b/react-app/src/mgWebGL.js
@@ -7993,7 +7993,7 @@ class MGWebGL extends Component {
             this.gl.uniform1f(this.shaderProgramTextBackground.fog_end, this.gl_fog_end);
         } else {
             //If we want them to be on top
-            this.gl.depthFunc(this.gl.ALWAYS);
+        this.gl.depthFunc(this.gl.ALWAYS);
             this.gl.uniform1f(this.shaderProgramTextBackground.fog_start, 1000.0);
             this.gl.uniform1f(this.shaderProgramTextBackground.fog_end, 1000.0);
         }
@@ -8556,8 +8556,8 @@ class MGWebGL extends Component {
                     self.reContourMaps();
                     return;
                 }
-                if (self.keysDown.m||self.keysDown.M) {
-                    if (self.clickedAtoms.length === 0 || (self.clickedAtoms[self.clickedAtoms.length - 1].length > 1 && self.keysDown.m)) {
+                if (self.keysDown['label_atom']) {
+                    if (self.clickedAtoms.length === 0 || (self.clickedAtoms[self.clickedAtoms.length - 1].length > 1 && self.keysDown['label_atom'])) {
                         self.clickedAtoms.push([]);
                         self.clickedAtoms[self.clickedAtoms.length - 1].push(theAtom);
                     } else {
@@ -10570,217 +10570,180 @@ class MGWebGL extends Component {
     }
 
     handleKeyUp(event, self) {
-        self.keysDown[event.key] = false;
+        for (const key of Object.keys(self.props.keyboardAccelerators)){
+            if(self.props.keyboardAccelerators[key].keyPress === event.key.toLowerCase() && self.props.keyboardAccelerators[key].modifiers.every(modifier => event[modifier])) {
+                self.keysDown[key] = false;
+            }
+        }
+    }
+
+    restoreScene(self) {
+        self.myQuat = quat4.create();
+        quat4.set(self.myQuat, 0, 0, 0, -1);
+        self.setZoom(1.0)
+        self.clickedAtoms = [];
+        self.drawScene();
+    }
+
+    moveLeft(self){
+        var invQuat = quat4.create();
+        quat4Inverse(self.myQuat, invQuat);
+        var theMatrix = quatToMat4(invQuat);
+        var xshift = vec3Create([-4. / getDeviceScale(), 0, 0]);
+        vec3.transformMat4(xshift, xshift, theMatrix);
+        self.origin[0] += xshift[0] / 8. * self.zoom;
+        self.origin[1] += xshift[1] / 8. * self.zoom;
+        self.origin[2] += xshift[2] / 8. * self.zoom;
+        const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
+        document.dispatchEvent(originChangeEvent);
+        self.drawSceneDirty();
+        self.reContourMaps();
+    }
+    
+    moveRight(self){
+        var invQuat = quat4.create();
+        quat4Inverse(self.myQuat, invQuat);
+        var theMatrix = quatToMat4(invQuat);
+        var xshift = vec3Create([4. / getDeviceScale(), 0, 0]);
+        vec3.transformMat4(xshift, xshift, theMatrix);
+        self.origin[0] += xshift[0] / 8. * self.zoom;
+        self.origin[1] += xshift[1] / 8. * self.zoom;
+        self.origin[2] += xshift[2] / 8. * self.zoom;
+        const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
+        document.dispatchEvent(originChangeEvent);
+        self.drawSceneDirty();
+        self.reContourMaps();
+    }
+
+    moveUp(self){
+        var invQuat = quat4.create();
+        quat4Inverse(self.myQuat, invQuat);
+        var theMatrix = quatToMat4(invQuat);
+        var yshift = vec3Create([0, 4. / getDeviceScale(), 0]);
+        vec3.transformMat4(yshift, yshift, theMatrix);
+        self.origin[0] += yshift[0] / 8. * self.zoom;
+        self.origin[1] += yshift[1] / 8. * self.zoom;
+        self.origin[2] += yshift[2] / 8. * self.zoom;
+        const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
+        document.dispatchEvent(originChangeEvent);
+        self.drawSceneDirty();
+        self.reContourMaps();
+    }
+        
+    moveDown(self){
+        var invQuat = quat4.create();
+        quat4Inverse(self.myQuat, invQuat);
+        var theMatrix = quatToMat4(invQuat);
+        var yshift = vec3Create([0, -4. / getDeviceScale(), 0]);
+        vec3.transformMat4(yshift, yshift, theMatrix);
+        self.origin[0] += yshift[0] / 8. * self.zoom;
+        self.origin[1] += yshift[1] / 8. * self.zoom;
+        self.origin[2] += yshift[2] / 8. * self.zoom;
+        const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
+        document.dispatchEvent(originChangeEvent);
+        self.drawSceneDirty();
+        self.reContourMaps();
+    }
+
+    takeScreenShot(event, self) {
+        var oldOrigin = [this.origin[0], this.origin[1], this.origin[2]];
+
+        // Getting up and right for doing tiling (in future?)
+        var invQuat = quat4.create();
+        quat4Inverse(this.myQuat, invQuat);
+
+        var invMat = quatToMat4(invQuat);
+
+        var right = vec3.create();
+        vec3.set(right, 1.0, 0.0, 0.0);
+        var up = vec3.create();
+        vec3.set(up, 0.0, 1.0, 0.0);
+
+        vec3.transformMat4(up, up, invMat);
+        vec3.transformMat4(right, right, invMat);
+
+        console.log(right);
+        console.log(up);
+        console.log(this.zoom);
+
+        var mag = 1;
+
+        var ncells_x = mag;
+        var ncells_y = mag;
+
+        var saveCanvas = document.createElement("canvas");
+        saveCanvas.width = this.canvas.width * ncells_x;
+        saveCanvas.height = this.canvas.height * ncells_y;
+        var ctx = saveCanvas.getContext("2d");
+
+        let newZoom = this.zoom / ncells_x
+        this.setZoom(newZoom)
+
+        var jj = 0;
+        for (var j = Math.floor(-ncells_y / 2); j < Math.floor(ncells_y / 2); j++) {
+            var ii = 0;
+            for (var i = Math.floor(-ncells_x / 2); i < Math.floor(ncells_x / 2); i++) {
+                var x_off = (2.0 * i + 1 + ncells_x % 2);
+                var y_off = (2.0 * j + 1 + ncells_y % 2);
+
+                this.origin = [oldOrigin[0], oldOrigin[1], oldOrigin[2]];
+                this.origin[0] += this.zoom * right[0] * 24.0 * x_off + this.zoom * up[0] * 24.0 * y_off;
+                this.origin[1] += this.zoom * right[1] * 24.0 * x_off + this.zoom * up[1] * 24.0 * y_off;
+                this.origin[2] += this.zoom * right[2] * 24.0 * x_off + this.zoom * up[2] * 24.0 * y_off;
+
+
+                self.save_pixel_data = true;
+                this.drawScene();
+                var pixels = self.pixel_data;
+
+                var imgData = ctx.createImageData(this.canvas.width, this.canvas.height);
+                var data = imgData.data;
+
+                for (var pixi = 0; pixi < this.canvas.height; pixi++) {
+                    for (var pixj = 0; pixj < this.canvas.width * 4; pixj++) {
+                        data[(this.canvas.height - pixi - 1) * this.canvas.width * 4 + pixj] = pixels[pixi * this.canvas.width * 4 + pixj];
+                    }
+                }
+                ctx.putImageData(imgData, (ncells_x - ii - 1) * this.canvas.width, jj * this.canvas.height);
+                ii++;
+            }
+            jj++;
+        }
+
+        newZoom = this.zoom * ncells_x
+        this.setZoom(newZoom)
+
+        this.origin = [oldOrigin[0], oldOrigin[1], oldOrigin[2]];
+        self.save_pixel_data = false;
+        this.drawScene();
+
+        let link = document.getElementById('download_image_link');
+        if(!link){
+            link = document.createElement('a');
+            link.id = 'download_image_link';
+            link.download = 'moorhen.png';
+            document.body.appendChild(link);
+        }
+        link.href = saveCanvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
+        link.click();
     }
 
     handleKeyDown(event, self) {
-        self.keysDown[event.key] = true;
-        if (event.key.toLowerCase() === "s") {
-            // Screenshot
-
-
-            var oldOrigin = [this.origin[0], this.origin[1], this.origin[2]];
-
-            // Getting up and right for doing tiling (in future?)
-            var invQuat = quat4.create();
-            quat4Inverse(this.myQuat, invQuat);
-
-            var invMat = quatToMat4(invQuat);
-
-            var right = vec3.create();
-            vec3.set(right, 1.0, 0.0, 0.0);
-            var up = vec3.create();
-            vec3.set(up, 0.0, 1.0, 0.0);
-
-            vec3.transformMat4(up, up, invMat);
-            vec3.transformMat4(right, right, invMat);
-
-            console.log(right);
-            console.log(up);
-            console.log(this.zoom);
-
-            var mag = 1;
-
-            var ncells_x = mag;
-            var ncells_y = mag;
-
-            var saveCanvas = document.createElement("canvas");
-            saveCanvas.width = this.canvas.width * ncells_x;
-            saveCanvas.height = this.canvas.height * ncells_y;
-            var ctx = saveCanvas.getContext("2d");
-
-            let newZoom = this.zoom / ncells_x
-            this.setZoom(newZoom)
-
-            var jj = 0;
-            for (var j = Math.floor(-ncells_y / 2); j < Math.floor(ncells_y / 2); j++) {
-                var ii = 0;
-                for (var i = Math.floor(-ncells_x / 2); i < Math.floor(ncells_x / 2); i++) {
-                    var x_off = (2.0 * i + 1 + ncells_x % 2);
-                    var y_off = (2.0 * j + 1 + ncells_y % 2);
-
-                    this.origin = [oldOrigin[0], oldOrigin[1], oldOrigin[2]];
-                    this.origin[0] += this.zoom * right[0] * 24.0 * x_off + this.zoom * up[0] * 24.0 * y_off;
-                    this.origin[1] += this.zoom * right[1] * 24.0 * x_off + this.zoom * up[1] * 24.0 * y_off;
-                    this.origin[2] += this.zoom * right[2] * 24.0 * x_off + this.zoom * up[2] * 24.0 * y_off;
-
-
-                    self.save_pixel_data = true;
-                    this.drawScene();
-                    var pixels = self.pixel_data;
-
-                    var imgData = ctx.createImageData(this.canvas.width, this.canvas.height);
-                    var data = imgData.data;
-
-                    for (var pixi = 0; pixi < this.canvas.height; pixi++) {
-                        for (var pixj = 0; pixj < this.canvas.width * 4; pixj++) {
-                            data[(this.canvas.height - pixi - 1) * this.canvas.width * 4 + pixj] = pixels[pixi * this.canvas.width * 4 + pixj];
-                        }
-                    }
-                    ctx.putImageData(imgData, (ncells_x - ii - 1) * this.canvas.width, jj * this.canvas.height);
-                    ii++;
-                }
-                jj++;
+        for (const key of Object.keys(self.props.keyboardAccelerators)){
+            if(self.props.keyboardAccelerators[key].keyPress === event.key.toLowerCase() && self.props.keyboardAccelerators[key].modifiers.every(modifier => event[modifier])) {
+                self.keysDown[key] = true;
             }
-
-            newZoom = this.zoom * ncells_x
-            this.setZoom(newZoom)
-
-            this.origin = [oldOrigin[0], oldOrigin[1], oldOrigin[2]];
-            self.save_pixel_data = false;
-            this.drawScene();
-
-            let link = document.getElementById('download_image_link');
-            if(!link){
-                link = document.createElement('a');
-                link.id = 'download_image_link';
-                link.download = 'moorhen.png';
-                document.body.appendChild(link);
-            }
-            link.href = saveCanvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
-            link.click();
         }
-
-        //MN Here invoke a keypress callback of provided in widget instantiation
-        //If callback returns false, then event response is terminated, and the 
-        //subsequent code is ignored
+       
         let doContinue = true
         if (this.props.onKeyPress) {
             doContinue = this.props.onKeyPress(event)
         }
+        /**
+         * No longer necessary but leaving it here in case we want to handle something
+         * not taken care of upstairs 
+         */
         if (! doContinue) return
-
-        // FIXME, we need an active map, like Coot.
-        if (event.key.toLowerCase() === "g") {
-            const frontAndBack = self.getFrontAndBackPos(event);
-            var goToBlobEvent = new CustomEvent("keyPressWithMousePosition", {
-                "detail": {
-                    back: [frontAndBack[0][0], frontAndBack[0][1], frontAndBack[0][2]],
-                    front: [frontAndBack[1][0], frontAndBack[1][1], frontAndBack[1][2]],
-                    windowX: frontAndBack[2],
-                    windowY: frontAndBack[3],
-                    key: 'G'
-                }
-            });
-            document.dispatchEvent(goToBlobEvent);
-        }
-
-        if (event.code === "Equal") { //+ (actually equals, sigh)
-            for (let ilm = 0; ilm < self.liveUpdatingMaps.length; ilm++) {
-                self.liveUpdatingMaps[ilm].contourLevel += 0.05;
-            }
-            self.drawSceneDirty();
-            self.reContourMaps();
-            self.drawScene();
-            if (self.liveUpdatingMaps.length > 0) {
-                var contourLevelChangeEvent = new CustomEvent("contourlevelchange", { "detail": self.liveUpdatingMaps[0].contourLevel });
-                document.dispatchEvent(contourLevelChangeEvent);
-            }
-        }
-        if (event.code === "Minus") { //-
-            for (let ilm = 0; ilm < self.liveUpdatingMaps.length; ilm++) {
-                self.liveUpdatingMaps[ilm].contourLevel -= 0.05;
-            }
-            self.drawSceneDirty();
-            self.reContourMaps();
-            self.drawScene();
-            if (self.liveUpdatingMaps.length > 0) {
-                var contourLevelChangeEvent = new CustomEvent("contourlevelchange", { "detail": self.liveUpdatingMaps[0].contourLevel });
-                document.dispatchEvent(contourLevelChangeEvent);
-            }
-        }
-        if (event.key.toLowerCase() === "r") {
-            self.myQuat = quat4.create();
-            quat4.set(self.myQuat, 0, 0, 0, -1);
-            self.setZoom(1.0)
-            self.clickedAtoms = [];
-            self.drawScene();
-        }
-        if (event.key.toLowerCase() === "c") {
-            self.clickedAtoms = [];
-            self.drawScene();
-        }
-        if (event.key === "ArrowLeft") {
-            var invQuat = quat4.create();
-            quat4Inverse(self.myQuat, invQuat);
-            var theMatrix = quatToMat4(invQuat);
-            var xshift = vec3Create([-4. / getDeviceScale(), 0, 0]);
-            vec3.transformMat4(xshift, xshift, theMatrix);
-            self.origin[0] += xshift[0] / 8. * self.zoom;
-            self.origin[1] += xshift[1] / 8. * self.zoom;
-            self.origin[2] += xshift[2] / 8. * self.zoom;
-            const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
-            document.dispatchEvent(originChangeEvent);
-            self.drawSceneDirty();
-            //console.log(self.origin);
-            self.reContourMaps();
-        }
-        if (event.key === "ArrowRight") {
-            var invQuat = quat4.create();
-            quat4Inverse(self.myQuat, invQuat);
-            var theMatrix = quatToMat4(invQuat);
-            var xshift = vec3Create([4. / getDeviceScale(), 0, 0]);
-            vec3.transformMat4(xshift, xshift, theMatrix);
-            self.origin[0] += xshift[0] / 8. * self.zoom;
-            self.origin[1] += xshift[1] / 8. * self.zoom;
-            self.origin[2] += xshift[2] / 8. * self.zoom;
-            const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
-            document.dispatchEvent(originChangeEvent);
-            self.drawSceneDirty();
-            //console.log(self.origin);
-            self.reContourMaps();
-        }
-        if (event.key === "ArrowUp") {
-            var invQuat = quat4.create();
-            quat4Inverse(self.myQuat, invQuat);
-            var theMatrix = quatToMat4(invQuat);
-            var yshift = vec3Create([0, 4. / getDeviceScale(), 0]);
-            vec3.transformMat4(yshift, yshift, theMatrix);
-            self.origin[0] += yshift[0] / 8. * self.zoom;
-            self.origin[1] += yshift[1] / 8. * self.zoom;
-            self.origin[2] += yshift[2] / 8. * self.zoom;
-            const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
-            document.dispatchEvent(originChangeEvent);
-            self.drawSceneDirty();
-            //console.log(self.origin);
-            self.reContourMaps();
-        }
-        if (event.key === "ArrowDown") {
-            var invQuat = quat4.create();
-            quat4Inverse(self.myQuat, invQuat);
-            var theMatrix = quatToMat4(invQuat);
-            var yshift = vec3Create([0, -4. / getDeviceScale(), 0]);
-            vec3.transformMat4(yshift, yshift, theMatrix);
-            self.origin[0] += yshift[0] / 8. * self.zoom;
-            self.origin[1] += yshift[1] / 8. * self.zoom;
-            self.origin[2] += yshift[2] / 8. * self.zoom;
-            const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
-            document.dispatchEvent(originChangeEvent);
-            self.drawSceneDirty();
-            //console.log(self.origin);
-            self.reContourMaps();
-        }
-
     }
 
     makeCircleCanvas(text, width, height, circleColour) {

--- a/react-app/src/mgWebGL.js
+++ b/react-app/src/mgWebGL.js
@@ -7993,7 +7993,7 @@ class MGWebGL extends Component {
             this.gl.uniform1f(this.shaderProgramTextBackground.fog_end, this.gl_fog_end);
         } else {
             //If we want them to be on top
-        this.gl.depthFunc(this.gl.ALWAYS);
+            this.gl.depthFunc(this.gl.ALWAYS);
             this.gl.uniform1f(this.shaderProgramTextBackground.fog_start, 1000.0);
             this.gl.uniform1f(this.shaderProgramTextBackground.fog_end, 1000.0);
         }

--- a/react-app/src/mgWebGL.js
+++ b/react-app/src/mgWebGL.js
@@ -10577,172 +10577,23 @@ class MGWebGL extends Component {
         }
     }
 
-    restoreScene(self) {
-        self.myQuat = quat4.create();
-        quat4.set(self.myQuat, 0, 0, 0, -1);
-        self.setZoom(1.0)
-        self.clickedAtoms = [];
-        self.drawScene();
-    }
-
-    moveLeft(self){
-        var invQuat = quat4.create();
-        quat4Inverse(self.myQuat, invQuat);
-        var theMatrix = quatToMat4(invQuat);
-        var xshift = vec3Create([-4. / getDeviceScale(), 0, 0]);
-        vec3.transformMat4(xshift, xshift, theMatrix);
-        self.origin[0] += xshift[0] / 8. * self.zoom;
-        self.origin[1] += xshift[1] / 8. * self.zoom;
-        self.origin[2] += xshift[2] / 8. * self.zoom;
-        const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
-        document.dispatchEvent(originChangeEvent);
-        self.drawSceneDirty();
-        self.reContourMaps();
-    }
-    
-    moveRight(self){
-        var invQuat = quat4.create();
-        quat4Inverse(self.myQuat, invQuat);
-        var theMatrix = quatToMat4(invQuat);
-        var xshift = vec3Create([4. / getDeviceScale(), 0, 0]);
-        vec3.transformMat4(xshift, xshift, theMatrix);
-        self.origin[0] += xshift[0] / 8. * self.zoom;
-        self.origin[1] += xshift[1] / 8. * self.zoom;
-        self.origin[2] += xshift[2] / 8. * self.zoom;
-        const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
-        document.dispatchEvent(originChangeEvent);
-        self.drawSceneDirty();
-        self.reContourMaps();
-    }
-
-    moveUp(self){
-        var invQuat = quat4.create();
-        quat4Inverse(self.myQuat, invQuat);
-        var theMatrix = quatToMat4(invQuat);
-        var yshift = vec3Create([0, 4. / getDeviceScale(), 0]);
-        vec3.transformMat4(yshift, yshift, theMatrix);
-        self.origin[0] += yshift[0] / 8. * self.zoom;
-        self.origin[1] += yshift[1] / 8. * self.zoom;
-        self.origin[2] += yshift[2] / 8. * self.zoom;
-        const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
-        document.dispatchEvent(originChangeEvent);
-        self.drawSceneDirty();
-        self.reContourMaps();
-    }
-        
-    moveDown(self){
-        var invQuat = quat4.create();
-        quat4Inverse(self.myQuat, invQuat);
-        var theMatrix = quatToMat4(invQuat);
-        var yshift = vec3Create([0, -4. / getDeviceScale(), 0]);
-        vec3.transformMat4(yshift, yshift, theMatrix);
-        self.origin[0] += yshift[0] / 8. * self.zoom;
-        self.origin[1] += yshift[1] / 8. * self.zoom;
-        self.origin[2] += yshift[2] / 8. * self.zoom;
-        const originChangeEvent = new CustomEvent("originChange", { "detail": self.origin });
-        document.dispatchEvent(originChangeEvent);
-        self.drawSceneDirty();
-        self.reContourMaps();
-    }
-
-    takeScreenShot(event, self) {
-        var oldOrigin = [this.origin[0], this.origin[1], this.origin[2]];
-
-        // Getting up and right for doing tiling (in future?)
-        var invQuat = quat4.create();
-        quat4Inverse(this.myQuat, invQuat);
-
-        var invMat = quatToMat4(invQuat);
-
-        var right = vec3.create();
-        vec3.set(right, 1.0, 0.0, 0.0);
-        var up = vec3.create();
-        vec3.set(up, 0.0, 1.0, 0.0);
-
-        vec3.transformMat4(up, up, invMat);
-        vec3.transformMat4(right, right, invMat);
-
-        console.log(right);
-        console.log(up);
-        console.log(this.zoom);
-
-        var mag = 1;
-
-        var ncells_x = mag;
-        var ncells_y = mag;
-
-        var saveCanvas = document.createElement("canvas");
-        saveCanvas.width = this.canvas.width * ncells_x;
-        saveCanvas.height = this.canvas.height * ncells_y;
-        var ctx = saveCanvas.getContext("2d");
-
-        let newZoom = this.zoom / ncells_x
-        this.setZoom(newZoom)
-
-        var jj = 0;
-        for (var j = Math.floor(-ncells_y / 2); j < Math.floor(ncells_y / 2); j++) {
-            var ii = 0;
-            for (var i = Math.floor(-ncells_x / 2); i < Math.floor(ncells_x / 2); i++) {
-                var x_off = (2.0 * i + 1 + ncells_x % 2);
-                var y_off = (2.0 * j + 1 + ncells_y % 2);
-
-                this.origin = [oldOrigin[0], oldOrigin[1], oldOrigin[2]];
-                this.origin[0] += this.zoom * right[0] * 24.0 * x_off + this.zoom * up[0] * 24.0 * y_off;
-                this.origin[1] += this.zoom * right[1] * 24.0 * x_off + this.zoom * up[1] * 24.0 * y_off;
-                this.origin[2] += this.zoom * right[2] * 24.0 * x_off + this.zoom * up[2] * 24.0 * y_off;
-
-
-                self.save_pixel_data = true;
-                this.drawScene();
-                var pixels = self.pixel_data;
-
-                var imgData = ctx.createImageData(this.canvas.width, this.canvas.height);
-                var data = imgData.data;
-
-                for (var pixi = 0; pixi < this.canvas.height; pixi++) {
-                    for (var pixj = 0; pixj < this.canvas.width * 4; pixj++) {
-                        data[(this.canvas.height - pixi - 1) * this.canvas.width * 4 + pixj] = pixels[pixi * this.canvas.width * 4 + pixj];
-                    }
-                }
-                ctx.putImageData(imgData, (ncells_x - ii - 1) * this.canvas.width, jj * this.canvas.height);
-                ii++;
-            }
-            jj++;
-        }
-
-        newZoom = this.zoom * ncells_x
-        this.setZoom(newZoom)
-
-        this.origin = [oldOrigin[0], oldOrigin[1], oldOrigin[2]];
-        self.save_pixel_data = false;
-        this.drawScene();
-
-        let link = document.getElementById('download_image_link');
-        if(!link){
-            link = document.createElement('a');
-            link.id = 'download_image_link';
-            link.download = 'moorhen.png';
-            document.body.appendChild(link);
-        }
-        link.href = saveCanvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
-        link.click();
-    }
-
     handleKeyDown(event, self) {
         for (const key of Object.keys(self.props.keyboardAccelerators)){
             if(self.props.keyboardAccelerators[key].keyPress === event.key.toLowerCase() && self.props.keyboardAccelerators[key].modifiers.every(modifier => event[modifier])) {
                 self.keysDown[key] = true;
             }
         }
-       
+
+        /**
+         * No longer necessary but leaving it here in case we want to handle something
+         * not taken care of upstairs 
+        */
+
         let doContinue = true
         if (this.props.onKeyPress) {
             doContinue = this.props.onKeyPress(event)
         }
-        /**
-         * No longer necessary but leaving it here in case we want to handle something
-         * not taken care of upstairs 
-         */
+
         if (! doContinue) return
     }
 


### PR DESCRIPTION
With this update the keyboard accelerators are unified within `BabyGruPreferences` and most of them are handled within `BabyGruKeyboardAccelerators`. However: 

- The main bodies of some functions (move up/down left/right and take screenshot) are still located within `mgWebGL`. At the moment, this works by just calling these functions in `BabyGruKeyboardAccelerators`. I can refactor the whole functions into `BabyGruKeyboardAccelerators` but I thought it would be tidier to keep all the `vec3` and `quat4` stuff within `mgWebGL`. Let me know if you think otherwise. In contrast, I did refactor all of the "go to blob" and "clear labels" code into `BabyGruKeyboardAccelerators`.
- Holding "m" and clicking on a residue is being taken care of within `mgWebGL`. To do this the attribute `self.keysDown` has been modified to contain information of which action can be performed based on the key mappings in `BabyGruPreferences`, which is now passed to `mgWebGL` via props.

@stuartjamesmcnicholas & @martinemnoble1 please let me know if I forgot to include another shortcut from `mgWebGL` or if you think there's a better way of doing this.