### PR TITLE
Control default map lit lines from preferences

### DIFF
--- a/baby-gru/src/components/BabyGruDisplayObjects.js
+++ b/baby-gru/src/components/BabyGruDisplayObjects.js
@@ -27,7 +27,6 @@ export const BabyGruDisplayObjects = (props) => {
                 map={map}
                 initialContour={0.8}
                 initialRadius={13}
-                initialMapLitLines={false}
                 currentDropdownMolNo={currentDropdownMolNo}
                 setCurrentDropdownMolNo={setCurrentDropdownMolNo}
                 {...props} />

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -10,7 +10,7 @@ export const BabyGruMapCard = (props) => {
     const [cootContour, setCootContour] = useState(true)
     const [mapRadius, setMapRadius] = useState(props.initialRadius)
     const [mapContourLevel, setMapContourLevel] = useState(props.initialContour)
-    const [mapLitLines, setMapLitLines] = useState(props.initialMapLitLines)    
+    const [mapLitLines, setMapLitLines] = useState(props.defaultLitLines)    
     const [isCollapsed, setIsCollapsed] = useState(!props.defaultExpandDisplayCards);
     const [currentName, setCurrentName] = useState(props.map.name);
     const nextOrigin = createRef([])
@@ -101,7 +101,6 @@ export const BabyGruMapCard = (props) => {
                     <DropdownButton 
                             title={<Settings/>}
                             size="sm" 
-                            title={<Settings />}
                             variant="outlined" 
                             autoClose={popoverIsShown ? false : 'outside'} 
                             show={props.currentDropdownMolNo === props.map.molNo} 
@@ -180,7 +179,7 @@ export const BabyGruMapCard = (props) => {
     useEffect(() => {
         setCootContour(props.map.cootContour)
         setMapContourLevel(props.initialContour)
-        setMapLitLines(props.initialMapLitLines)
+        setMapLitLines(props.defaultLitLines)
         setMapRadius(props.initialRadius)
     }, [])
 

--- a/baby-gru/src/components/BabyGruPreferencesMenu.js
+++ b/baby-gru/src/components/BabyGruPreferencesMenu.js
@@ -4,7 +4,7 @@ import { BabyGruShortcutConfigModal } from "./BabyGruShortcutConfigModal"
 import { MenuItem } from "@mui/material";
 
 export const BabyGruPreferencesMenu = (props) => {
-    const { atomLabelDepthMode, setAtomLabelDepthMode, darkMode, setDarkMode, defaultExpandDisplayCards, setDefaultExpandDisplayCards } = props;
+    const { atomLabelDepthMode, setAtomLabelDepthMode, darkMode, setDarkMode, defaultExpandDisplayCards, setDefaultExpandDisplayCards, defaultLitLines, setDefaultLitLines } = props;
     const [showModal, setShowModal] = useState(null);
 
     return <NavDropdown
@@ -34,6 +34,13 @@ export const BabyGruPreferencesMenu = (props) => {
                         checked={atomLabelDepthMode}
                         onChange={() => { setAtomLabelDepthMode(!atomLabelDepthMode) }}
                         label="Depth cue atom labels"/>
+                </InputGroup>
+                <InputGroup style={{ padding:'0.5rem', width: '20rem'}}>
+                    <Form.Check 
+                        type="switch"
+                        checked={defaultLitLines}
+                        onChange={() => { setDefaultLitLines(!defaultLitLines) }}
+                        label="Activate map lit lines by default"/>
                 </InputGroup>
                 <MenuItem variant="success" onClick={() => setShowModal(true)}>
                     Configure shortcuts

--- a/baby-gru/src/utils/BabyGruPreferences.js
+++ b/baby-gru/src/utils/BabyGruPreferences.js
@@ -16,6 +16,7 @@ const getDefaultValues = () => {
         darkMode: false, 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,
+        defaultLitLines: false,
         shortCuts: {
             "sphere_refine": {
                 modifiers: ["shiftKey"],
@@ -118,6 +119,7 @@ const PreferencesContextProvider = ({ children }) => {
     const [atomLabelDepthMode, setAtomLabelDepthMode] = useState(null);
     const [defaultExpandDisplayCards, setDefaultExpandDisplayCards] = useState(null);
     const [shortCuts, setShortCuts] = useState(null);
+    const [defaultLitLines, setDefaultLitLines] = useState(null);
 
     const restoreDefaults = ( )=> {
         const defaultValues = getDefaultValues()
@@ -126,6 +128,7 @@ const PreferencesContextProvider = ({ children }) => {
         setDefaultExpandDisplayCards(defaultValues.defaultExpandDisplayCards)            
         setShortCuts(JSON.stringify(defaultValues.shortCuts))            
         setAtomLabelDepthMode(defaultValues.atomLabelDepthMode)
+        setDefaultLitLines(defaultValues.defaultLitLines)
     }
 
     /**
@@ -142,7 +145,8 @@ const PreferencesContextProvider = ({ children }) => {
                     localforage.getItem('darkMode'), 
                     localforage.getItem('defaultExpandDisplayCards'),
                     localforage.getItem('shortCuts'),
-                    localforage.getItem('atomLabelDepthMode')
+                    localforage.getItem('atomLabelDepthMode'),
+                    localforage.getItem('defaultLitLines')
                     ])
                 
                 console.log('Retrieved the following preferences from local storage: ', response)
@@ -160,6 +164,7 @@ const PreferencesContextProvider = ({ children }) => {
                     setDefaultExpandDisplayCards(response[2])
                     setShortCuts(response[3])
                     setAtomLabelDepthMode(response[4])
+                    setDefaultLitLines(response[5])
                 }                
                 
             } catch (err) {
@@ -213,7 +218,16 @@ const PreferencesContextProvider = ({ children }) => {
         updateStoredPreferences('shortCuts', shortCuts);
     }, [shortCuts]);
 
-    const collectedContextValues = {darkMode, setDarkMode, atomLabelDepthMode, setAtomLabelDepthMode, defaultExpandDisplayCards, setDefaultExpandDisplayCards, shortCuts, setShortCuts}
+    useMemo(() => {
+
+        if (defaultLitLines === null) {
+            return
+        }
+       
+        updateStoredPreferences('defaultLitLines', defaultLitLines);
+    }, [defaultLitLines]);
+
+    const collectedContextValues = {darkMode, setDarkMode, atomLabelDepthMode, setAtomLabelDepthMode, defaultExpandDisplayCards, setDefaultExpandDisplayCards, shortCuts, setShortCuts, defaultLitLines, setDefaultLitLines}
 
     return (
       <PreferencesContext.Provider value={collectedContextValues}>


### PR DESCRIPTION
With this update, users can control from preferences whether map lit lines should be on/off by default.