### PR TITLE
Fit buttons on the bottom bar into a carousel

### DIFF
--- a/baby-gru/src/components/BabyGruButtonBar.js
+++ b/baby-gru/src/components/BabyGruButtonBar.js
@@ -1,7 +1,7 @@
 import { CheckOutlined, CloseOutlined } from "@mui/icons-material";
-import { Menu, MenuItem, MenuList, Tooltip } from "@mui/material";
+import { MenuItem, MenuList, Tooltip } from "@mui/material";
 import { createRef, forwardRef, useCallback, useEffect, useRef, useState } from "react";
-import { ButtonGroup, Button, Overlay, Container, Row, FormSelect, FormGroup, FormLabel, Card } from "react-bootstrap"
+import { ButtonGroup, Button, Overlay, Container, Row, FormSelect, FormGroup, FormLabel, Card, Carousel } from "react-bootstrap"
 import { BabyGruMoleculeSelect } from "./BabyGruMoleculeSelect";
 import { cidToSpec } from "../utils/BabyGruUtils";
 
@@ -14,6 +14,72 @@ const refinementFormatArgs = (molecule, chosenAtom, pp) => {
 
 export const BabyGruButtonBar = (props) => {
     const [selectedButtonIndex, setSelectedButtonIndex] = useState(null);
+
+    const editButtons = [
+        (<BabyGruAutofitRotamerButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="0" />),
+
+        (<BabyGruFlipPeptideButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="1" />),
+
+        (<BabyGruSideChain180Button {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="2" />),
+
+        (<BabyGruRefineResiduesUsingAtomCidButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="3" />),
+
+        (<BabyGruDeleteUsingCidButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="4" />),
+
+        (<BabyGruMutateButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="5" />),
+
+        (<BabyGruAddTerminalResidueDirectlyUsingCidButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="6" />),
+
+        (<BabyGruEigenFlipLigandButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="7" />),
+
+        (<BabyGruJedFlipFalseButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="8" />),
+
+        (<BabyGruJedFlipTrueButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="9" />),
+
+        (<BabyGruRotateTranslateZoneButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="10" />),
+
+        (<BabyGruAddSimpleButton {...props} selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="11" />)
+    
+    ]
+
+    const getCarouselItems = () => {
+        const maximumAllowedWidth = props.windowWidth - (props.innerWindowMarginWidth + (props.showSideBar ? props.sideBarWidth : 0))
+
+        let currentlyUsedWidth = 0
+        let carouselItems = []
+        let currentItem = []
+
+        editButtons.forEach(button => {
+            currentItem.push(button)
+            currentlyUsedWidth += 120
+            if (currentlyUsedWidth >= maximumAllowedWidth) {
+                carouselItems.push(currentItem)
+                currentItem = []
+                currentlyUsedWidth = 0
+            }
+        })
+        
+        if (currentItem.length > 0) {
+            carouselItems.push(currentItem)
+        }
+
+        return carouselItems
+    }
+
+    const carouselItems = getCarouselItems()
+
     return <div
         style={{
             overflow: "auto",
@@ -23,45 +89,17 @@ export const BabyGruButtonBar = (props) => {
                 ${255 * props.backgroundColor[2]}, 
                 ${props.backgroundColor[3]})`,
         }}>
-        <ButtonGroup>
-
-            <BabyGruAutofitRotamerButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="0" />
-
-            <BabyGruFlipPeptideButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="1" />
-
-            <BabyGruSideChain180Button {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="2" />
-
-            <BabyGruRefineResiduesUsingAtomCidButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="3" />
-
-            <BabyGruDeleteUsingCidButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="4" />
-
-            <BabyGruMutateButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="5" />
-
-            <BabyGruAddTerminalResidueDirectlyUsingCidButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="6" />
-
-            <BabyGruEigenFlipLigandButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="7" />
-
-            <BabyGruJedFlipFalseButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="8" />
-
-            <BabyGruJedFlipTrueButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="9" />
-
-            <BabyGruRotateTranslateZoneButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="10" />
-
-            <BabyGruAddSimpleButton {...props} selectedButtonIndex={selectedButtonIndex}
-                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="11" />
-
-        </ButtonGroup>
+            <Carousel variant={props.darkMode ? "light" : "dark"} interval={null} keyboard={false} indicators={false} controls={carouselItems.length > 1}>
+                {carouselItems.map(item => {
+                    return (
+                        <Carousel.Item>
+                        <ButtonGroup>
+                            {item}
+                        </ButtonGroup>
+                        </Carousel.Item>
+                    )
+                })}
+            </Carousel>
     </div>
 }
 

--- a/baby-gru/src/components/BabyGruButtonBar.js
+++ b/baby-gru/src/components/BabyGruButtonBar.js
@@ -89,16 +89,22 @@ export const BabyGruButtonBar = (props) => {
                 ${255 * props.backgroundColor[2]}, 
                 ${props.backgroundColor[3]})`,
         }}>
-            <Carousel variant={props.darkMode ? "light" : "dark"} interval={null} keyboard={false} indicators={false} controls={carouselItems.length > 1}>
-                {carouselItems.map(item => {
-                    return (
-                        <Carousel.Item>
-                        <ButtonGroup>
-                            {item}
-                        </ButtonGroup>
-                        </Carousel.Item>
-                    )
-                })}
+            <Carousel 
+                variant={props.darkMode ? "light" : "dark"} 
+                interval={null} 
+                keyboard={false} 
+                indicators={false} 
+                onSlide={() => setSelectedButtonIndex(-1)}
+                controls={carouselItems.length > 1}>
+                    {carouselItems.map(item => {
+                        return (
+                            <Carousel.Item>
+                            <ButtonGroup>
+                                {item}
+                            </ButtonGroup>
+                            </Carousel.Item>
+                        )
+                    })}
             </Carousel>
     </div>
 }

--- a/baby-gru/src/components/BabyGruButtonBar.js
+++ b/baby-gru/src/components/BabyGruButtonBar.js
@@ -184,6 +184,7 @@ export const BabyGruSimpleEditButton = forwardRef((props, buttonRef) => {
                 ref={buttonRef ? buttonRef : target}
                 active={props.buttonIndex === props.selectedButtonIndex}
                 variant='light'
+                style={{borderColor: props.buttonIndex === props.selectedButtonIndex ? 'red' : ''}}
                 disabled={props.needsMapData && !props.activeMap ||
                     (props.needsAtomData && props.molecules.length === 0)}
                 onClick={(e) => {

--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -260,7 +260,7 @@ export const BabyGruContainer = (props) => {
         molecules, changeMolecules, appTitle, setAppTitle, maps, changeMaps, glRef, activeMolecule, setActiveMolecule,
         activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor, sideBarWidth,
         navBarRef, currentDropdownId, setCurrentDropdownId, hoveredAtom, setHoveredAtom, toastContent, setToastContent, 
-        showToast, setShowToast, ...preferences
+        showToast, setShowToast, windowWidth, windowHeight, showSideBar, innerWindowMarginWidth, ...preferences
     }
 
     const accordionToolsItemProps = {


### PR DESCRIPTION
After this update the button bar on the bottom of the screen will become a carousel. As we add more buttons it could become problematic to fit all of them into a single bar specially in small displays, so this takes care of it by fitting buttons into different carousel items depending on the available space (sensitive to screen re-size). I'm not sure if this is the best solution from the UI perspective so this is also a bit of an experiment, I would like to know what people think about it. The change is easy to revert anyway.