### PR TITLE
Fix button bar bug

### DIFF
--- a/baby-gru/src/components/BabyGruButtonBar.js
+++ b/baby-gru/src/components/BabyGruButtonBar.js
@@ -63,7 +63,7 @@ export const BabyGruButtonBar = (props) => {
 
         editButtons.forEach(button => {
             currentItem.push(button)
-            currentlyUsedWidth += 120
+            currentlyUsedWidth += 90
             if (currentlyUsedWidth >= maximumAllowedWidth) {
                 carouselItems.push(currentItem)
                 currentItem = []

--- a/baby-gru/src/components/BabyGruButtonBar.js
+++ b/baby-gru/src/components/BabyGruButtonBar.js
@@ -177,6 +177,19 @@ export const BabyGruSimpleEditButton = forwardRef((props, buttonRef) => {
         })
     }, [props.molecules.length, props.activeMap, props.refineAfterMod])
 
+    useEffect(() => {
+        props.setCursorStyle("crosshair")
+        if (props.awaitAtomClick && props.selectedButtonIndex === props.buttonIndex) {
+            props.setCursorStyle("crosshair")
+            document.addEventListener('atomClicked', atomClickedCallback, { once: true })
+        }
+
+        return () => {
+            props.setCursorStyle("default")
+            document.removeEventListener('atomClicked', atomClickedCallback, { once: true })
+        }
+    }, [props.selectedButtonIndex])
+
     return <>
         <Tooltip title={props.toolTip}>
             <Button value={props.buttonIndex}
@@ -187,18 +200,8 @@ export const BabyGruSimpleEditButton = forwardRef((props, buttonRef) => {
                 style={{borderColor: props.buttonIndex === props.selectedButtonIndex ? 'red' : ''}}
                 disabled={props.needsMapData && !props.activeMap ||
                     (props.needsAtomData && props.molecules.length === 0)}
-                onClick={(e) => {
-                    if (props.selectedButtonIndex === e.currentTarget.value) {
-                        props.setSelectedButtonIndex(null)
-                        props.setCursorStyle("default")
-                        document.removeEventListener('atomClicked', atomClickedCallback, { once: true })
-                        return
-                    }
-                    props.setSelectedButtonIndex(props.buttonIndex)
-                    props.setCursorStyle("crosshair")
-                    if (props.awaitAtomClick) {
-                        document.addEventListener('atomClicked', atomClickedCallback, { once: true })
-                    }
+                onClick={(evt) => {
+                    props.setSelectedButtonIndex(props.buttonIndex !== props.selectedButtonIndex ? props.buttonIndex : null)
                 }}>
                 {props.icon}
             </Button>


### PR DESCRIPTION
This fixes a bug I have recently discovered: if a given edit button is no longer active, the event listener waiting for the user to pick up an atom is not removed. It only gets removed if the user clicks again on the same button to deactivate it. If, instead, the user clicks on a different button while the previous one was still active, the second button then becomes active, and there are two even listeners added. By putting this inside a hook with a cleanup function this is fixed. It also prevents multiple buttons being active at once is the user switches between different carousel items.