### PR TITLE
Add preferences to draw crosshairs and missing loops

### DIFF
--- a/baby-gru/src/components/BabyGruPreferencesMenu.js
+++ b/baby-gru/src/components/BabyGruPreferencesMenu.js
@@ -9,7 +9,8 @@ export const BabyGruPreferencesMenu = (props) => {
         atomLabelDepthMode, setAtomLabelDepthMode, darkMode, setDarkMode, 
         defaultExpandDisplayCards, setDefaultExpandDisplayCards, defaultLitLines,
         setDefaultLitLines, refineAfterMod, setRefineAfterMod, mouseSensitivity,
-        setMouseSensitivity
+        setMouseSensitivity, drawCrosshairs, setDrawCrosshairs, drawMissingLoops,
+        setDrawMissingLoops
      } = props;
     const [showModal, setShowModal] = useState(null);
 
@@ -54,6 +55,20 @@ export const BabyGruPreferencesMenu = (props) => {
                         checked={refineAfterMod}
                         onChange={() => { setRefineAfterMod(!refineAfterMod) }}
                         label="Automatic triple refine post-modification"/>
+                </InputGroup>
+                <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
+                    <Form.Check 
+                        type="switch"
+                        checked={drawCrosshairs}
+                        onChange={() => { setDrawCrosshairs(!drawCrosshairs) }}
+                        label="Show crosshairs"/>
+                </InputGroup>
+                <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
+                    <Form.Check 
+                        type="switch"
+                        checked={drawMissingLoops}
+                        onChange={() => { setDrawMissingLoops(!drawMissingLoops) }}
+                        label="Show missing loops"/>
                 </InputGroup>
                 <Form.Group controlId="mouseSensitivitySlider" style={{paddingTop:'0.5rem', paddingBottom:'0.5rem', paddingRight:'0.5rem', paddingLeft:'1rem', width: '25rem'}}>
                     <BabyGruSlider minVal={0.1} maxVal={10.0} logScale={false} sliderTitle="Mouse sensitivity" intialValue={2.5} externalValue={mouseSensitivity} setExternalValue={setMouseSensitivity}/>

--- a/baby-gru/src/components/BabyGruWebMG.js
+++ b/baby-gru/src/components/BabyGruWebMG.js
@@ -89,7 +89,9 @@ export const BabyGruWebMG = forwardRef((props, glRef) => {
         onKeyPress={props.onKeyPress}
         messageChanged={() => { }}
         mouseSensitivityFactor={props.preferences.mouseSensitivity}
-        keyboardAccelerators={JSON.parse(props.preferences.shortCuts)}/>
+        keyboardAccelerators={JSON.parse(props.preferences.shortCuts)}
+        drawCrosshairs={props.preferences.drawCrosshairs}
+        drawMissingLoops={props.drawMissingLoops}/>
 });
 
 

--- a/baby-gru/src/utils/BabyGruPreferences.js
+++ b/baby-gru/src/utils/BabyGruPreferences.js
@@ -12,12 +12,14 @@ const updateStoredPreferences = async (key, value) => {
 
 const getDefaultValues = () => {
     return {
-        version: '0.0.2',
+        version: '0.0.3',
         darkMode: false, 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,
         defaultLitLines: false,
         refineAfterMod: true,
+        drawCrosshairs: true,
+        drawMissingLoops: true,
         mouseSensitivity: 2.0,
         shortCuts: {
             "sphere_refine": {
@@ -130,6 +132,8 @@ const PreferencesContextProvider = ({ children }) => {
     const [defaultLitLines, setDefaultLitLines] = useState(null)
     const [refineAfterMod, setRefineAfterMod] = useState(null)
     const [mouseSensitivity, setMouseSensitivity] = useState(null)
+    const [drawCrosshairs, setDrawCrosshairs] = useState(null)
+    const [drawMissingLoops, setDrawMissingLoops] = useState(null)
 
     const restoreDefaults = (defaultValues)=> {
         updateStoredPreferences('version', defaultValues.version)
@@ -140,6 +144,8 @@ const PreferencesContextProvider = ({ children }) => {
         setDefaultLitLines(defaultValues.defaultLitLines)
         setRefineAfterMod(defaultValues.refineAfterMod)
         setMouseSensitivity(defaultValues.mouseSensitivity)
+        setDrawCrosshairs(defaultValues.drawCrosshairs)
+        setDrawMissingLoops(defaultValues.drawMissingLoops)
     }
 
     /**
@@ -159,7 +165,9 @@ const PreferencesContextProvider = ({ children }) => {
                     localforage.getItem('atomLabelDepthMode'),
                     localforage.getItem('defaultLitLines'),
                     localforage.getItem('refineAfterMod'),
-                    localforage.getItem('mouseSensitivity')
+                    localforage.getItem('mouseSensitivity'),
+                    localforage.getItem('drawCrosshairs'),
+                    localforage.getItem('drawMissingLoops')
                     ])
                 
                 console.log('Retrieved the following preferences from local storage: ', response)
@@ -180,6 +188,8 @@ const PreferencesContextProvider = ({ children }) => {
                     setDefaultLitLines(response[5])
                     setRefineAfterMod(response[6])
                     setMouseSensitivity(response[7])
+                    setDrawCrosshairs(response[8])
+                    setDrawMissingLoops(response[9])
                 }                
                 
             } catch (err) {
@@ -205,6 +215,24 @@ const PreferencesContextProvider = ({ children }) => {
        
         updateStoredPreferences('refineAfterMod', refineAfterMod);
     }, [refineAfterMod]);
+
+    useMemo(() => {
+
+        if (drawCrosshairs === null) {
+            return
+        }
+       
+        updateStoredPreferences('drawCrosshairs', drawCrosshairs);
+    }, [drawCrosshairs]);
+
+    useMemo(() => {
+
+        if (drawMissingLoops === null) {
+            return
+        }
+       
+        updateStoredPreferences('drawMissingLoops', drawMissingLoops);
+    }, [drawMissingLoops]);
 
     useMemo(() => {
 


### PR DESCRIPTION
As requested by @martinemnoble1 I've added the option to draw crosshairs and missing loops into the preferences container. These new preferences are passed to `mgWebGL` via props from `BabyGruWebMG`.