### PR TITLE
Fix three minor bugs and merge molecules from molecule card

### DIFF
--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -252,7 +252,6 @@ export const BabyGruContainer = (props) => {
 
     const getAccordionHeight = () => {
         let navBarHeight = parseFloat(window.getComputedStyle(document.getElementById('navbar-baby-gru')).height);
-        let buttonBarHeight = parseFloat(window.getComputedStyle(document.getElementById('button-bar-baby-gru')).height);
         return windowHeight - (navBarHeight + innerWindowMarginHeight)
     }
 
@@ -264,7 +263,8 @@ export const BabyGruContainer = (props) => {
     }
 
     const accordionToolsItemProps = {
-        molecules, commandCentre, glRef, toolAccordionBodyHeight, sideBarWidth, windowHeight, windowWidth, maps, showSideBar, ...preferences
+        molecules, commandCentre, glRef, toolAccordionBodyHeight, sideBarWidth, windowHeight, windowWidth, maps, showSideBar, 
+        hoveredAtom, setHoveredAtom,...preferences
     }
 
     return <> <div className={`border ${theme}`} ref={headerRef}>
@@ -275,9 +275,9 @@ export const BabyGruContainer = (props) => {
             <Navbar.Collapse id="basic-navbar-nav">
                 <Nav className="justify-content-left">
                     <BabyGruFileMenu dropdownId={1} {...collectedProps} />
-                    <BabyGruHistoryMenu dropdownId={2} {...collectedProps} />
+                    <BabyGruLigandMenu dropdownId={2} {...collectedProps} />
                     <BabyGruViewMenu dropdownId={3} {...collectedProps} />
-                    <BabyGruLigandMenu dropdownId={4} {...collectedProps} />
+                    <BabyGruHistoryMenu dropdownId={4} {...collectedProps} />
                     <BabyGruPreferencesMenu dropdownId={5} {...collectedProps} />
                     {props.extraMenus && props.extraMenus.map(menu=>menu)}
                 </Nav>

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -868,14 +868,18 @@ export const BabyGruMergeMoleculesMenuItem = (props) => {
 
     const panelContent = <>
         <BabyGruMoleculeSelect {...props} label="Into molecule" allowAny={false} ref={toRef} />
-        <BabyGruMoleculeSelect {...props} label="From molecule" allowAny={false} ref={fromRef} />
+        {props.fromMolNo === null ? <BabyGruMoleculeSelect {...props} label="From molecule" allowAny={false} ref={fromRef}/> : null}
     </>
 
     const onCompleted = useCallback(async () => {
         const toMolecule = props.molecules
             .filter(molecule => molecule.molNo === parseInt(toRef.current.value))[0]
         const otherMolecules = props.molecules
-            .filter(molecule => molecule.molNo === parseInt(fromRef.current.value))
+            .filter(molecule => molecule.molNo === parseInt(props.fromMolNo !== null ? props.fromMolNo : fromRef.current.value) && molecule.molNo !== toMolecule.molNo)
+        if (!otherMolecules.length > 0){
+            console.log('No valid molecules selected, skipping merge...')
+            return
+        }
         console.log({ toMolecule, otherMolecules })
         let banan = await toMolecule.mergeMolecules(otherMolecules, props.glRef, true)
         console.log({ banan })
@@ -883,12 +887,18 @@ export const BabyGruMergeMoleculesMenuItem = (props) => {
     }, [toRef.current, fromRef.current, props.molecules])
 
     return <BabyGruMenuItem
-        popoverPlacement='right'
+        popoverPlacement={props.popoverPlacement}
         popoverContent={panelContent}
-        menuItemText="Merge molecules..."
+        menuItemText={props.menuItemText}
         onCompleted={onCompleted}
         setPopoverIsShown={props.setPopoverIsShown}
     />
+}
+
+BabyGruMergeMoleculesMenuItem.defaultProps = {
+    popoverPlacement: "right",
+    menuItemText: 'Merge molecules...',
+    fromMolNo: null
 }
 
 export const BabyGruAddWatersMenuItem = (props) => {

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -4,7 +4,7 @@ import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
 import { doDownload, sequenceIsValid } from '../utils/BabyGruUtils';
 import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined, DownloadOutlined, Settings } from '@mui/icons-material';
 import { BabyGruSequenceViewer } from "./BabyGruSequenceViewer";
-import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem } from "./BabyGruMenuItem";
+import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem, BabyGruMergeMoleculesMenuItem } from "./BabyGruMenuItem";
 
 export const BabyGruMoleculeCard = (props) => {
     const [showState, setShowState] = useState({})
@@ -164,18 +164,23 @@ export const BabyGruMoleculeCard = (props) => {
             }
         },
         6: {
-            label: 'Refine selected residues',
-            compressed: () => { return (<MenuItem key={6} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleResidueRangeRefinement}>Refine selected residues</MenuItem>) },
+            label: 'Merge molecules',
+            compressed: () => { return (<BabyGruMergeMoleculesMenuItem key={6} glRef={props.glRef} molecules={props.molecules} setPopoverIsShown={setPopoverIsShown} menuItemText="Merge molecule into..." popoverPlacement='left' fromMolNo={props.molecule.molNo}/>) },
             expanded: null
         },
         7: {
-            label: 'Rename molecule',
-            compressed: () => { return (<BabyGruRenameDisplayObjectMenuItem key={7} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
+            label: 'Refine selected residues',
+            compressed: () => { return (<MenuItem key={7} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleResidueRangeRefinement}>Refine selected residues</MenuItem>) },
             expanded: null
         },
         8: {
+            label: 'Rename molecule',
+            compressed: () => { return (<BabyGruRenameDisplayObjectMenuItem key={8} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
+            expanded: null
+        },
+        9: {
             label: 'Copy selected residues into fragment',
-            compressed: () => { return (<MenuItem key={8} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>) },
+            compressed: () => { return (<MenuItem key={9} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>) },
             expanded: null
         },
     }

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -165,17 +165,17 @@ export const BabyGruMoleculeCard = (props) => {
         },
         6: {
             label: 'Refine selected residues',
-            compressed: () => { return (<MenuItem key={8} variant="success" onClick={handleResidueRangeRefinement}>Refine selected residues</MenuItem>) },
+            compressed: () => { return (<MenuItem key={6} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleResidueRangeRefinement}>Refine selected residues</MenuItem>) },
             expanded: null
         },
         7: {
             label: 'Rename molecule',
-            compressed: () => { return (<BabyGruRenameDisplayObjectMenuItem key={6} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
+            compressed: () => { return (<BabyGruRenameDisplayObjectMenuItem key={7} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
             expanded: null
         },
         8: {
             label: 'Copy selected residues into fragment',
-            compressed: () => { return (<MenuItem key={7} variant="success" onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>) },
+            compressed: () => { return (<MenuItem key={8} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>) },
             expanded: null
         },
     }

--- a/baby-gru/src/components/BabyGruSequenceViewer.js
+++ b/baby-gru/src/components/BabyGruSequenceViewer.js
@@ -81,6 +81,7 @@ export const BabyGruSequenceViewer = (props) => {
             if (evt.detail.eventtype === "click") {
                 if (evt.detail.feature !== null && !(evt.detail.highlight.includes(','))) {
                     props.setClickedResidue({modelIndex:0, molName:props.molecule.name, chain:props.sequence.chain, seqNum:evt.detail.feature.start})
+                    props.setSelectedResidues(null)
                 } else if (evt.detail.highlight.includes(',')) {
                     let residues = evt.detail.highlight.split(',').map(residue => parseInt(residue.split(':')[0]))
                     props.setSelectedResidues([Math.min(...residues), Math.max(...residues)])


### PR DESCRIPTION
This fixes two bugs:

- Ramachandran plot not working due to `hoveredAtom` missing from props.
- The residue range selected with the sequence viewer did not clear after selecting a new residue outside the range.