### PR TITLE
Connect sequence viewer with hoveredAtom and add mapLineWidth to preferences

### DIFF
--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -329,6 +329,8 @@ export const BabyGruMoleculeCard = (props) => {
                                     setClickedResidue={setClickedResidue}
                                     selectedResidues={selectedResidues}
                                     setSelectedResidues={setSelectedResidues}
+                                    hoveredAtom={props.hoveredAtom}
+                                    setHoveredAtom={props.setHoveredAtom}
                                 />)
                             }
                         )

--- a/baby-gru/src/components/BabyGruPreferencesMenu.js
+++ b/baby-gru/src/components/BabyGruPreferencesMenu.js
@@ -10,7 +10,7 @@ export const BabyGruPreferencesMenu = (props) => {
         defaultExpandDisplayCards, setDefaultExpandDisplayCards, defaultLitLines,
         setDefaultLitLines, refineAfterMod, setRefineAfterMod, mouseSensitivity,
         setMouseSensitivity, drawCrosshairs, setDrawCrosshairs, drawMissingLoops,
-        setDrawMissingLoops
+        setDrawMissingLoops, mapLineWidth, setMapLineWidth
      } = props;
     const [showModal, setShowModal] = useState(null);
 
@@ -72,6 +72,9 @@ export const BabyGruPreferencesMenu = (props) => {
                 </InputGroup>
                 <Form.Group controlId="mouseSensitivitySlider" style={{paddingTop:'0.5rem', paddingBottom:'0.5rem', paddingRight:'0.5rem', paddingLeft:'1rem', width: '25rem'}}>
                     <BabyGruSlider minVal={0.1} maxVal={10.0} logScale={false} sliderTitle="Mouse sensitivity" intialValue={2.5} externalValue={mouseSensitivity} setExternalValue={setMouseSensitivity}/>
+                </Form.Group>
+                <Form.Group controlId="mapLineWidthSensitivitySlider" style={{paddingTop:'0.5rem', paddingBottom:'0.5rem', paddingRight:'0.5rem', paddingLeft:'1rem', width: '25rem'}}>
+                    <BabyGruSlider minVal={0.1} maxVal={5.0} logScale={true} sliderTitle="Map lines thickness" intialValue={2.5} externalValue={mapLineWidth} setExternalValue={setMapLineWidth}/>
                 </Form.Group>
                 <MenuItem variant="success" onClick={() => setShowModal(true)} >
                     Configure shortcuts

--- a/baby-gru/src/components/BabyGruSequenceViewer.js
+++ b/baby-gru/src/components/BabyGruSequenceViewer.js
@@ -124,6 +124,32 @@ export const BabyGruSequenceViewer = (props) => {
         sequenceRef.current.trackHighlighter.changedCallBack('highlightstart', resNum)
         sequenceRef.current.trackHighlighter.changedCallBack('highlightend', resNum)
     } 
+
+    /**
+     * Hook used to handle hovering events on the visualisation panel
+     */
+    useEffect(() => {
+        if (props.hoveredAtom===null || props.hoveredAtom.molecule === null || props.hoveredAtom.cid === null || sequenceRef.current === null) {
+            return
+        }
+
+        const [_, insCode, chainId, resInfo, atomName]   = props.hoveredAtom.cid.split('/')
+
+        if (chainId !== props.sequence.chain || !resInfo) {
+            return
+        }
+        
+        const resNum = resInfo.split('(')[0]
+        
+        if (!resNum) {
+            return
+        }
+        
+        setMessage(props.hoveredAtom.cid)
+        setHighlight(resNum)
+
+    }, [props.hoveredAtom])
+
     
     /**
      * Callback to handle changes in the protvista component
@@ -140,8 +166,8 @@ export const BabyGruSequenceViewer = (props) => {
             }
         } else if (evt.detail.eventtype === "mouseover") {
             if (evt.detail.feature !== null) {
-                setMessage(`/${evt.detail.feature.start} (${props.sequence.type==="polypeptide(L)" ? residueCodesOneToThree[evt.detail.feature.aa] : nucleotideCodesOneToThree[evt.detail.feature.aa]})`)
-                setHighlight(evt.detail.feature.start)
+                const cid =`//${props.sequence.chain}/${evt.detail.feature.start}(${props.sequence.type==="polypeptide(L)" ? residueCodesOneToThree[evt.detail.feature.aa] : nucleotideCodesOneToThree[evt.detail.feature.aa]})/CA`
+                props.setHoveredAtom({ molecule: props.molecule, cid: cid })
             }
         } else if (evt.detail.eventtype === "mouseout") {
             setMessage("")
@@ -235,7 +261,7 @@ export const BabyGruSequenceViewer = (props) => {
 
     return (
         <div className='align-items-center' style={{marginBottom:'0', padding:'0'}}>
-            <span>{`${props.molecule.name}/${props.sequence.chain}${message}`}</span>
+            <span>{`${props.molecule.name}${message ? "" : "/" + props.sequence.chain}${message}`}</span>
             <div style={{width: '100%'}}>
                 <protvista-manager ref={managerRef}>
                     <protvista-navigation 

--- a/baby-gru/src/components/BabyGruSequenceViewer.js
+++ b/baby-gru/src/components/BabyGruSequenceViewer.js
@@ -125,6 +125,9 @@ export const BabyGruSequenceViewer = (props) => {
         sequenceRef.current.trackHighlighter.changedCallBack('highlightend', resNum)
     } 
     
+    /**
+     * Callback to handle changes in the protvista component
+     */
     const handleChange = useCallback((evt) => {
         if (evt.detail.eventtype === "click") {
             if (evt.detail.feature !== null && !(evt.detail.highlight.includes(','))) {
@@ -150,7 +153,7 @@ export const BabyGruSequenceViewer = (props) => {
      * Hook used to control mouse events. Adds an event listener on the protvista-sequence component for mouse clicks 
      * and mouse over. It will also disable mouse double click.
      */
-     useEffect(()=> {
+    useEffect(()=> {
         
         if (sequenceRef.current === null) {
             return;
@@ -172,13 +175,13 @@ export const BabyGruSequenceViewer = (props) => {
             }
         };
         
-      }, [handleChange]);    
+    }, [handleChange]);    
     
     /**
      * Hook used to control mouse events. Adds an event listener on the protvista-sequence component for mouse clicks 
      * and mouse over. It will also disable mouse double click.
      */
-     useEffect(()=> {
+    useEffect(()=> {
         
         if (selectedResiduesTrackRef.current === null) {
             return;
@@ -187,12 +190,12 @@ export const BabyGruSequenceViewer = (props) => {
         sequenceRef.current.trackHighlighter.element._highlightcolor = hoveredResidueColor
         selectedResiduesTrackRef.current.trackHighlighter.element._highlightcolor = transparentColor
         
-      }, []);    
+    }, []);    
     
     /**
      * Hook used to clear the current selection if user selects residue from different chain
      */
-     useEffect(() => {       
+    useEffect(() => {       
         if (props.clickedResidue && props.clickedResidue.chain != props.sequence.chain) {
             clearSelection()
         } else if (props.clickedResidue && !props.selectedResidues) {
@@ -205,7 +208,6 @@ export const BabyGruSequenceViewer = (props) => {
      * Hook used to set a range of highlighted residues
      */
     useEffect(()=> {
-        console.log(props.clickedResidue)
         if (props.selectedResidues !== null  && props.clickedResidue.chain === props.sequence.chain) {
           setSelection(...props.selectedResidues)
         }

--- a/baby-gru/src/components/BabyGruSequenceViewer.js
+++ b/baby-gru/src/components/BabyGruSequenceViewer.js
@@ -1,11 +1,13 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState, useCallback } from "react"
 import { residueCodesOneToThree, nucleotideCodesOneToThree } from '../utils/BabyGruUtils'
 import ProtvistaManager from "protvista-manager";
 import ProtvistaSequence from "protvista-sequence";
 import ProtvistaNavigation from "protvista-navigation";
+import ProtvistaTrack from "protvista-track";
 
 window.customElements.define("protvista-navigation", ProtvistaNavigation);
 window.customElements.define("protvista-sequence", ProtvistaSequence);
+window.customElements.define("protvista-track", ProtvistaTrack);
 window.customElements.define("protvista-manager", ProtvistaManager);
     
 /**
@@ -44,17 +46,35 @@ export const BabyGruSequenceViewer = (props) => {
     const managerRef = useRef(null);
     const sequenceRef = useRef(null);
     const navigationRef = useRef(null);
+    const selectedResiduesTrackRef = useRef(null)
     const [message, setMessage] = useState("");
     const [rulerStart, seqLenght, displaySequence] = parseSequenceData(props.sequence.sequence)
     const [start, end] = calculateDisplayStartAndEnd(rulerStart, seqLenght);
+    const hoveredResidueColor = '#FFEB3B66'
+    const transparentColor = '#FFEB3B00'
 
 
     /**
      * Clear highlighted residue range
      */
     const clearSelection = () => {
-        sequenceRef.current.trackHighlighter.changedCallBack('highlightstart', null)
-        sequenceRef.current.trackHighlighter.changedCallBack('highlightend', null)
+        const dummyData = [
+            {
+                "accession": "backgroundLine",
+                "color": "red",
+                "shape": "line",
+                "start": "",
+                "end": ""
+            },
+            {
+                "accession": "Outliers",
+                "shape": "triangle",
+                "color": "red",
+                "locations": [{"fragments": []}]
+            }
+        ]
+
+        selectedResiduesTrackRef.current.data = dummyData
     }
     
     /**
@@ -63,36 +83,77 @@ export const BabyGruSequenceViewer = (props) => {
      * @param {Number} end The last residue of the range
      */
     const setSelection = (start, end) => {
-        sequenceRef.current.trackHighlighter.changedCallBack('highlightstart', start)
-        sequenceRef.current.trackHighlighter.changedCallBack('highlightend', end)
+
+        let fragments = [{
+            "start": start,
+            "end": start
+        }]
+
+        if (end !== null) {
+            fragments.push({
+                "start": end,
+                "end": end
+            })
+        }
+
+        const selectedResiduesTrackData  = [
+            {
+                "accession": "backgroundLine",
+                "color": "red",
+                "shape": "line",
+                "start": start,
+                "end": end ? end : start
+            },
+            {
+                "accession": "Outliers",
+                "shape": "triangle",
+                "color": "red",
+                "locations": [{"fragments": fragments}]
+            }
+        ]
+      
+        selectedResiduesTrackRef.current.data = selectedResiduesTrackData
     }
+
+    /**
+     * Sets a highlighted residue in the sequence viewer 
+     * @param {Number} start The first residues of the range
+     * @param {Number} end The last residue of the range
+     */
+    const setHighlight = (resNum) => {
+        sequenceRef.current.trackHighlighter.changedCallBack('highlightstart', resNum)
+        sequenceRef.current.trackHighlighter.changedCallBack('highlightend', resNum)
+    } 
+    
+    const handleChange = useCallback((evt) => {
+        if (evt.detail.eventtype === "click") {
+            if (evt.detail.feature !== null && !(evt.detail.highlight.includes(','))) {
+                props.setClickedResidue({modelIndex:0, molName:props.molecule.name, chain:props.sequence.chain, seqNum:evt.detail.feature.start})
+                props.setSelectedResidues(null)
+            } else if (evt.detail.highlight.includes(',')) {
+                let residues = [props.clickedResidue.seqNum, evt.detail.feature.start]
+                props.setSelectedResidues([Math.min(...residues), Math.max(...residues)])
+                props.setClickedResidue({modelIndex:0, molName:props.molecule.name, chain:props.sequence.chain, seqNum:evt.detail.feature.start})
+            }
+        } else if (evt.detail.eventtype === "mouseover") {
+            if (evt.detail.feature !== null) {
+                setMessage(`/${evt.detail.feature.start} (${props.sequence.type==="polypeptide(L)" ? residueCodesOneToThree[evt.detail.feature.aa] : nucleotideCodesOneToThree[evt.detail.feature.aa]})`)
+                setHighlight(evt.detail.feature.start)
+            }
+        } else if (evt.detail.eventtype === "mouseout") {
+            setMessage("")
+        }
+    }, [props.clickedResidue])
+
 
     /**
      * Hook used to control mouse events. Adds an event listener on the protvista-sequence component for mouse clicks 
      * and mouse over. It will also disable mouse double click.
      */
-    useEffect(()=> {
+     useEffect(()=> {
         
         if (sequenceRef.current === null) {
             return;
-        }
-
-        const handleChange = (evt) => {
-            if (evt.detail.eventtype === "click") {
-                if (evt.detail.feature !== null && !(evt.detail.highlight.includes(','))) {
-                    props.setClickedResidue({modelIndex:0, molName:props.molecule.name, chain:props.sequence.chain, seqNum:evt.detail.feature.start})
-                    props.setSelectedResidues(null)
-                } else if (evt.detail.highlight.includes(',')) {
-                    let residues = evt.detail.highlight.split(',').map(residue => parseInt(residue.split(':')[0]))
-                    props.setSelectedResidues([Math.min(...residues), Math.max(...residues)])
-                }
-            } else if (evt.detail.eventtype === "mouseover") {
-                if (evt.detail.feature !== null) {
-                    setMessage(`/${evt.detail.feature.start} (${props.sequence.type==="polypeptide(L)" ? residueCodesOneToThree[evt.detail.feature.aa] : nucleotideCodesOneToThree[evt.detail.feature.aa]})`)
-                }
-            } else if (evt.detail.eventtype === "mouseout") {
-                setMessage("")
-            }
         }
 
         const disableDoubleClick = (evt) => {
@@ -111,6 +172,21 @@ export const BabyGruSequenceViewer = (props) => {
             }
         };
         
+      }, [handleChange]);    
+    
+    /**
+     * Hook used to control mouse events. Adds an event listener on the protvista-sequence component for mouse clicks 
+     * and mouse over. It will also disable mouse double click.
+     */
+     useEffect(()=> {
+        
+        if (selectedResiduesTrackRef.current === null) {
+            return;
+        }
+        
+        sequenceRef.current.trackHighlighter.element._highlightcolor = hoveredResidueColor
+        selectedResiduesTrackRef.current.trackHighlighter.element._highlightcolor = transparentColor
+        
       }, []);    
     
     /**
@@ -119,13 +195,17 @@ export const BabyGruSequenceViewer = (props) => {
      useEffect(() => {       
         if (props.clickedResidue && props.clickedResidue.chain != props.sequence.chain) {
             clearSelection()
+        } else if (props.clickedResidue && !props.selectedResidues) {
+            setSelection(props.clickedResidue.seqNum, null)
         }
+
     }, [props.clickedResidue]);
 
     /**
      * Hook used to set a range of highlighted residues
      */
     useEffect(()=> {
+        console.log(props.clickedResidue)
         if (props.selectedResidues !== null  && props.clickedResidue.chain === props.sequence.chain) {
           setSelection(...props.selectedResidues)
         }
@@ -144,11 +224,15 @@ export const BabyGruSequenceViewer = (props) => {
             navigationRef.current._displaystart = start
             navigationRef.current._displayend = end
         }
+        if(selectedResiduesTrackRef){
+            selectedResiduesTrackRef.current._displaystart = start
+            selectedResiduesTrackRef.current._displayend = end
+        }
         
     }, [props.sequence]);
 
     return (
-        <div className='align-items-center' style={{marginBottom:'1rem', padding:'0'}}>
+        <div className='align-items-center' style={{marginBottom:'0', padding:'0'}}>
             <span>{`${props.molecule.name}/${props.sequence.chain}${message}`}</span>
             <div style={{width: '100%'}}>
                 <protvista-manager ref={managerRef}>
@@ -167,6 +251,14 @@ export const BabyGruSequenceViewer = (props) => {
                         numberofticks="10"
                         displaystart={start}
                         displayend={end}
+                        use-ctrl-to-zoom
+                        />
+                    <protvista-track 
+                        ref={selectedResiduesTrackRef}
+                        length={seqLenght} 
+                        displaystart={start}
+                        displayend={end}
+                        height='10'
                         use-ctrl-to-zoom
                         />
                 </protvista-manager>

--- a/baby-gru/src/utils/BabyGruPreferences.js
+++ b/baby-gru/src/utils/BabyGruPreferences.js
@@ -12,7 +12,7 @@ const updateStoredPreferences = async (key, value) => {
 
 const getDefaultValues = () => {
     return {
-        version: '0.0.3',
+        version: '0.0.4',
         darkMode: false, 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,
@@ -21,6 +21,7 @@ const getDefaultValues = () => {
         drawCrosshairs: true,
         drawMissingLoops: true,
         mouseSensitivity: 2.0,
+        mapLineWidth: 1.0,
         shortCuts: {
             "sphere_refine": {
                 modifiers: ["shiftKey"],
@@ -134,6 +135,7 @@ const PreferencesContextProvider = ({ children }) => {
     const [mouseSensitivity, setMouseSensitivity] = useState(null)
     const [drawCrosshairs, setDrawCrosshairs] = useState(null)
     const [drawMissingLoops, setDrawMissingLoops] = useState(null)
+    const [mapLineWidth, setMapLineWidth] = useState(null)
 
     const restoreDefaults = (defaultValues)=> {
         updateStoredPreferences('version', defaultValues.version)
@@ -146,6 +148,7 @@ const PreferencesContextProvider = ({ children }) => {
         setMouseSensitivity(defaultValues.mouseSensitivity)
         setDrawCrosshairs(defaultValues.drawCrosshairs)
         setDrawMissingLoops(defaultValues.drawMissingLoops)
+        setMapLineWidth(defaultValues.mapLineWidth)
     }
 
     /**
@@ -167,7 +170,8 @@ const PreferencesContextProvider = ({ children }) => {
                     localforage.getItem('refineAfterMod'),
                     localforage.getItem('mouseSensitivity'),
                     localforage.getItem('drawCrosshairs'),
-                    localforage.getItem('drawMissingLoops')
+                    localforage.getItem('drawMissingLoops'),
+                    localforage.getItem('mapLineWidth')
                     ])
                 
                 console.log('Retrieved the following preferences from local storage: ', response)
@@ -190,6 +194,7 @@ const PreferencesContextProvider = ({ children }) => {
                     setMouseSensitivity(response[7])
                     setDrawCrosshairs(response[8])
                     setDrawMissingLoops(response[9])
+                    setMapLineWidth(response[10])
                 }                
                 
             } catch (err) {
@@ -215,6 +220,15 @@ const PreferencesContextProvider = ({ children }) => {
        
         updateStoredPreferences('refineAfterMod', refineAfterMod);
     }, [refineAfterMod]);
+
+    useMemo(() => {
+
+        if (mapLineWidth === null) {
+            return
+        }
+       
+        updateStoredPreferences('mapLineWidth', mapLineWidth);
+    }, [mapLineWidth]);
 
     useMemo(() => {
 
@@ -292,7 +306,7 @@ const PreferencesContextProvider = ({ children }) => {
         darkMode, setDarkMode, atomLabelDepthMode, setAtomLabelDepthMode, defaultExpandDisplayCards,
         setDefaultExpandDisplayCards, shortCuts, setShortCuts, defaultLitLines, setDefaultLitLines,
         refineAfterMod, setRefineAfterMod, mouseSensitivity, setMouseSensitivity, drawCrosshairs, 
-        setDrawCrosshairs, drawMissingLoops, setDrawMissingLoops
+        setDrawCrosshairs, drawMissingLoops, setDrawMissingLoops, mapLineWidth, setMapLineWidth
     }
 
     return (

--- a/react-app/src/Ramachandran.js
+++ b/react-app/src/Ramachandran.js
@@ -211,7 +211,6 @@ class RamaPlot extends Component {
             const hit = this.getHit(event,self);
             this.hit = hit;
             if(hit>-1){
-                this.doAnimation(oldHit, self)
                 this.props.setHoveredAtom(`/${this.state.plotInfo[hit].insCode}/${this.state.chainId}/${this.state.plotInfo[hit].seqNum}(${this.state.plotInfo[hit].restype})/CA`)
             };
         }


### PR DESCRIPTION
After this update the sequence viewer will be connected to `hoveredAtom`. This means hovering over a residue in the sequence viewer, the ramachandran plot or in the visualisation panel will highlight that same residue in all three components. In this new sequence viewer, hovered residues are highlighted in yellow, which means an alternative visual clue had to be used for residues and ranges of residues clicked in the sequence viewer (these are used as input for "copy fragment" and "refine residue range"). Since it is not possible to have multiple separate ranges of residues with different colours highlighted in `protvista-sequence`, this is now done using an additional `protvista-track` to highlight selected residues. 