### PR TITLE
Fix pepflip widget and other UI changes

### DIFF
--- a/baby-gru/src/components/BabyGruPepflipsDifferenceMap.js
+++ b/baby-gru/src/components/BabyGruPepflipsDifferenceMap.js
@@ -105,7 +105,7 @@ export const BabyGruPepflipsDifferenceMap = (props) => {
             message:'coot_command',
             command: "pepflips_using_difference_map", 
             returnType:'interesting_places_data',
-            commandArgs:[selectedMap, selectedModel, selectedRmsd]
+            commandArgs:[selectedModel, selectedMap, selectedRmsd]
         }
     
         fetchData(inputData)   

--- a/baby-gru/src/components/BabyGruPepflipsDifferenceMap.js
+++ b/baby-gru/src/components/BabyGruPepflipsDifferenceMap.js
@@ -58,9 +58,9 @@ export const BabyGruPepflipsDifferenceMap = (props) => {
                 }, true)    
             }
 
-            let selectedMoleculeIndex = props.molecules.findIndex(molecule => molecule.molNo == selectedModel);
-            props.molecules[selectedMoleculeIndex].setAtomsDirty(true)
-            props.molecules[selectedMoleculeIndex].redraw(props.glRef)
+            const selectedMolecule = props.molecules.find(molecule => molecule.molNo == selectedModel)
+            selectedMolecule.setAtomsDirty(true)
+            selectedMolecule.redraw(props.glRef)
             //Here use originChanged event to force recontour (relevant for live updating maps)
             const originChangedEvent = new CustomEvent("originChanged",
                 { "detail": props.glRef.current.origin });

--- a/baby-gru/src/components/BabyGruValidation.js
+++ b/baby-gru/src/components/BabyGruValidation.js
@@ -152,6 +152,10 @@ export const BabyGruValidation = (props) => {
         if(selectedMolecule) {
             const clickedResidue = getResidueInfo(selectedMolecule, residueIndex)
             if (clickedResidue) {
+                props.setHoveredAtom({
+                    molecule: selectedMolecule,
+                    cid:  `//${clickedResidue.chain}/${clickedResidue.seqNum}(${residueCodesOneToThree[clickedResidue.resCode]})`
+                })
                 return `${clickedResidue.seqNum} (${residueCodesOneToThree[clickedResidue.resCode]})`
             }
         }


### PR DESCRIPTION
This update includes:
- Validation widget is now connected with `hoveredAtom` just like the other widgets.
- Peptide flip widget is fixed and it shows now a list of peptides. The cards include a "View" button and a "Flip" button.
- Actual peak rmsd is shown when hovering over bars in the difference map peaks widget.