### PR TITLE
Add coot bond options and other UI fixes

### DIFF
--- a/baby-gru/src/components/BabyGruButtonBar.js
+++ b/baby-gru/src/components/BabyGruButtonBar.js
@@ -283,7 +283,7 @@ export const BabyGruConvertCisTransButton = (props) => {
         needsMapData={false}
         cootCommand="cis_trans_convert"
         prompt="Click atom in residue to convert"
-        icon={<img className="baby-gru-button-icon" alt="Cis/Trans" src="/baby-gru/pixmaps/cis-trans.png" />}
+        icon={<img className="baby-gru-button-icon" alt="Cis/Trans" src="/baby-gru/pixmaps/cis-trans.svg" />}
         formatArgs={(molecule, chosenAtom) => {
             return [molecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}`, '']
         }} />

--- a/baby-gru/src/components/BabyGruButtonBar.js
+++ b/baby-gru/src/components/BabyGruButtonBar.js
@@ -50,8 +50,11 @@ export const BabyGruButtonBar = (props) => {
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="10" />),
 
         (<BabyGruAddSimpleButton {...props} selectedButtonIndex={selectedButtonIndex}
-            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="11" />)
-    
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="11" />),
+        
+        (<BabyGruConvertCisTransButton {...props} selectedButtonIndex={selectedButtonIndex}
+                setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="12" />),
+
     ]
 
     const getCarouselItems = () => {
@@ -266,6 +269,21 @@ export const BabyGruFlipPeptideButton = (props) => {
         cootCommand="flipPeptide_cid"
         prompt="Click atom in residue to flip"
         icon={<img className="baby-gru-button-icon" src="/baby-gru/pixmaps/flip-peptide.svg" />}
+        formatArgs={(molecule, chosenAtom) => {
+            return [molecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}`, '']
+        }} />
+}
+
+export const BabyGruConvertCisTransButton = (props) => {
+    return <BabyGruSimpleEditButton {...props}
+        toolTip="Cis/Trans isomerisation"
+        buttonIndex={props.buttonIndex}
+        selectedButtonIndex={props.selectedButtonIndex}
+        setSelectedButtonIndex={props.setSelectedButtonIndex}
+        needsMapData={false}
+        cootCommand="cis_trans_convert"
+        prompt="Click atom in residue to convert"
+        icon={<img className="baby-gru-button-icon" alt="Cis/Trans" src="/baby-gru/pixmaps/cis-trans.png" />}
         formatArgs={(molecule, chosenAtom) => {
             return [molecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}`, '']
         }} />

--- a/baby-gru/src/components/BabyGruContainer.js
+++ b/baby-gru/src/components/BabyGruContainer.js
@@ -95,7 +95,9 @@ export const BabyGruContainer = (props) => {
         let head = document.head;
         let style = document.createElement("link");
 
-        if (preferences.darkMode) {
+        if (preferences.darkMode === null) {
+            return
+        } else if (preferences.darkMode) {
             style.href = "/baby-gru/darkly.css"
             setTheme("darkly")
             setBackgroundColor([0., 0., 0., 1.])
@@ -114,6 +116,20 @@ export const BabyGruContainer = (props) => {
 
     }, [preferences.darkMode])
 
+    useEffect(() => {
+        async function setDrawMissingLoopAPI() {
+            await commandCentre.current.cootCommand({
+                command: 'set_draw_missing_residue_loops',
+                commandArgs: [preferences.drawMissingLoops],
+                returnType: "status"
+            })
+        }
+
+        if (commandCentre.current && preferences.drawMissingLoops !== null && cootInitialized) {
+            setDrawMissingLoopAPI()
+        }
+
+    }, [preferences.drawMissingLoops, cootInitialized])
 
     useEffect(() => {
         commandCentre.current = new BabyGruCommandCentre({

--- a/baby-gru/src/components/BabyGruEditMenu.js
+++ b/baby-gru/src/components/BabyGruEditMenu.js
@@ -16,6 +16,7 @@ export const BabyGruEditMenu = (props) => {
         <NavDropdown
             title="Edit"
             id="basic-nav-dropdown-edit"
+            autoClose={popoverIsShown ? false : 'outside'}
             show={props.currentDropdownId === props.dropdownId}
             onToggle={() => { props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1) }}>
             <BabyGruMergeMoleculesMenuItem key="merge" {...menuItemProps} />

--- a/baby-gru/src/components/BabyGruMapCard.js
+++ b/baby-gru/src/components/BabyGruMapCard.js
@@ -216,8 +216,9 @@ export const BabyGruMapCard = (props) => {
     return <Card className="px-0"  style={{marginBottom:'0.5rem', padding:'0'}} key={props.map.molNo}>
         <Card.Header>
             <Row className='align-items-center'>
-            <Col style={{display:'flex', justifyContent:'left'}}>
+            <Col className='align-items-center' style={{display:'flex', justifyContent:'left'}}>
                     {`#${props.map.molNo} Map ${props.map.name}`}
+                    <img className="baby-gru-map-icon" alt="..." src={props.map.isDifference ? "/baby-gru/pixmaps/diff-map.png" : "/baby-gru/pixmaps/map.svg"} style={{width: '20px', height: '20px', margin:'0.5rem', padding:'0'}}/>
             </Col>
             <Col style={{display:'flex', justifyContent:'right'}}>
                 {getButtonBar(props.sideBarWidth)}

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -220,6 +220,35 @@ export const BabyGruRenameDisplayObjectMenuItem = (props) => {
     />
 }
 
+export const BabyGruMoleculeBondSettingsMenuItem = (props) => {
+    const smoothnesSelectRef = useRef(null)
+
+    const panelContent = 
+    <>
+        <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="BabyGruBondWidthSlider">
+            <BabyGruSlider minVal={0.05} maxVal={0.5} logScale={false} sliderTitle="Bond width" intialValue={0.1} externalValue={props.bondWidth} setExternalValue={props.setBondWidth}/>
+        </Form.Group>
+        <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="BabyGruRadiusBondRatioSlider">
+            <BabyGruSlider minVal={1.0} maxVal={3.5} logScale={false} sliderTitle="Radius-Bond ratio" intialValue={1.5} externalValue={props.atomRadiusBondRatio} setExternalValue={props.setAtomRadiusBondRatio}/>
+        </Form.Group>
+        <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="BabyGruSmoothnessSelector">
+            <Form.Label>Smoothness</Form.Label>
+            <FormSelect size="sm" ref={smoothnesSelectRef} defaultValue={props.bondSmoothness} onChange={(evt) => {props.setBondSmoothness(evt.target.value)}}>
+                <option value={1} key={1}>Coarse</option>
+                <option value={2} key={2}>Nice</option>
+                <option value={3} key={3}>Smooth</option>
+            </FormSelect>
+        </Form.Group>
+    </>
+
+    return <BabyGruMenuItem
+        popoverPlacement='left'
+        popoverContent={panelContent}
+        menuItemText={"Bond settings"}
+        onCompleted={() => {}}
+        setPopoverIsShown={props.setPopoverIsShown}
+    />
+}
 
 export const BabyGruDeleteEverythingMenuItem = (props) => {
 

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -36,16 +36,16 @@ export const BabyGruMoleculeCard = (props) => {
             return
         }
 
-        const newBackgroundIsDark = isDarkBackground(props.backgroundColor)
-        if (props.molecule.cootBondsOptions.isDarkBackground !== newBackgroundIsDark) {
-            props.molecule.cootBondsOptions.isDarkBackground = newBackgroundIsDark
-            if (isVisible && showState['CBs']) {
+        if (isVisible && showState['CBs']) {
+            const newBackgroundIsDark = isDarkBackground(props.backgroundColor)
+            if (props.molecule.cootBondsOptions.isDarkBackground !== newBackgroundIsDark){
+                props.molecule.cootBondsOptions.isDarkBackground = newBackgroundIsDark
                 props.molecule.setAtomsDirty(true)
                 props.molecule.redraw(props.glRef)        
-            }    
+            }
         }
 
-    }, [props.backgroundColor]);
+    }, [props.backgroundColor, showState]);
 
     useEffect(() => {
         if (bondSmoothness === null) {

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -2,6 +2,7 @@ import { MenuItem } from "@mui/material";
 import { useEffect, useState, useMemo, Fragment } from "react";
 import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
 import { doDownload, sequenceIsValid } from '../utils/BabyGruUtils';
+import { isDarkBackground } from '../WebGL/mgWebGL'
 import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined, DownloadOutlined, Settings } from '@mui/icons-material';
 import { BabyGruSequenceViewer } from "./BabyGruSequenceViewer";
 import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem, BabyGruMoleculeBondSettingsMenuItem } from "./BabyGruMenuItem";
@@ -18,14 +19,6 @@ export const BabyGruMoleculeCard = (props) => {
     const [atomRadiusBondRatio, setAtomRadiusBondRatio] = useState(1.5)
     const [bondSmoothness, setBondSmoothness] = useState(1)
 
-    const isDarkBackground = (backgroundColor) => {
-        const bright_y = backgroundColor[0] * 0.299 + backgroundColor[1] * 0.587 + backgroundColor[2] * 0.114
-        if (bright_y >= 0.5) {
-            return false
-        }
-        return true
-    }
-
     const  bondSettingsProps = {
         bondWidth, setBondWidth, atomRadiusBondRatio, 
         setAtomRadiusBondRatio, bondSmoothness, setBondSmoothness
@@ -37,7 +30,7 @@ export const BabyGruMoleculeCard = (props) => {
         }
 
         if (isVisible && showState['CBs']) {
-            const newBackgroundIsDark = isDarkBackground(props.backgroundColor)
+            const newBackgroundIsDark = isDarkBackground(...props.backgroundColor)
             if (props.molecule.cootBondsOptions.isDarkBackground !== newBackgroundIsDark){
                 props.molecule.cootBondsOptions.isDarkBackground = newBackgroundIsDark
                 props.molecule.setAtomsDirty(true)

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -25,6 +25,18 @@ export const BabyGruMoleculeCard = (props) => {
     }
 
     useEffect(() => {
+        if (props.drawMissingLoops === null) {
+            return
+        }
+
+        if (isVisible && showState['CBs']) {
+            props.molecule.setAtomsDirty(true)
+            props.molecule.redraw(props.glRef)        
+        }
+
+    }, [props.drawMissingLoops])
+
+    useEffect(() => {
         if (props.backgroundColor === null) {
             return
         }

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -304,8 +304,9 @@ export const BabyGruMoleculeCard = (props) => {
     return <Card className="px-0" style={{ marginBottom: '0.5rem', padding: '0' }} key={props.molecule.molNo}>
         <Card.Header>
             <Row className='align-items-center'>
-                <Col style={{ display: 'flex', justifyContent: 'left' }}>
+            <Col className='align-items-center' style={{display:'flex', justifyContent:'left'}}>
                     {`#${props.molecule.molNo} Mol. ${props.molecule.name}`}
+                    <img className="baby-gru-map-icon" alt="..." src= "/baby-gru/pixmaps/secondary-structure.svg" style={{width: '20px', height: '20px', margin:'0.5rem', padding:'0'}}/>
                 </Col>
                 <Col style={{ display: 'flex', justifyContent: 'right' }}>
                     {getButtonBar(props.sideBarWidth)}

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -4,7 +4,7 @@ import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
 import { doDownload, sequenceIsValid } from '../utils/BabyGruUtils';
 import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined, DownloadOutlined, Settings } from '@mui/icons-material';
 import { BabyGruSequenceViewer } from "./BabyGruSequenceViewer";
-import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem, BabyGruMergeMoleculesMenuItem } from "./BabyGruMenuItem";
+import { BabyGruDeleteDisplayObjectMenuItem, BabyGruRenameDisplayObjectMenuItem, BabyGruMoleculeBondSettingsMenuItem } from "./BabyGruMenuItem";
 
 export const BabyGruMoleculeCard = (props) => {
     const [showState, setShowState] = useState({})
@@ -14,6 +14,77 @@ export const BabyGruMoleculeCard = (props) => {
     const [isCollapsed, setIsCollapsed] = useState(!props.defaultExpandDisplayCards);
     const [popoverIsShown, setPopoverIsShown] = useState(false)
     const [isVisible, setIsVisible] = useState(true)
+    const [bondWidth, setBondWidth] = useState(0.1)
+    const [atomRadiusBondRatio, setAtomRadiusBondRatio] = useState(1.5)
+    const [bondSmoothness, setBondSmoothness] = useState(1)
+
+    const isDarkBackground = (backgroundColor) => {
+        const bright_y = backgroundColor[0] * 0.299 + backgroundColor[1] * 0.587 + backgroundColor[2] * 0.114
+        if (bright_y >= 0.5) {
+            return false
+        }
+        return true
+    }
+
+    const  bondSettingsProps = {
+        bondWidth, setBondWidth, atomRadiusBondRatio, 
+        setAtomRadiusBondRatio, bondSmoothness, setBondSmoothness
+    }
+
+    useEffect(() => {
+        if (props.backgroundColor === null) {
+            return
+        }
+
+        const newBackgroundIsDark = isDarkBackground(props.backgroundColor)
+        if (props.molecule.cootBondsOptions.isDarkBackground !== newBackgroundIsDark) {
+            props.molecule.cootBondsOptions.isDarkBackground = newBackgroundIsDark
+            if (isVisible && showState['CBs']) {
+                props.molecule.setAtomsDirty(true)
+                props.molecule.redraw(props.glRef)        
+            }    
+        }
+
+    }, [props.backgroundColor]);
+
+    useEffect(() => {
+        if (bondSmoothness === null) {
+            return
+        }
+        
+        props.molecule.cootBondsOptions.smoothness = bondSmoothness
+        if (isVisible && showState['CBs']) {
+            props.molecule.setAtomsDirty(true)
+            props.molecule.redraw(props.glRef)        
+        }
+
+    }, [bondSmoothness]);
+
+    useEffect(() => {
+        if (bondWidth === null) {
+            return
+        }
+
+        props.molecule.cootBondsOptions.width = bondWidth
+        if (isVisible && showState['CBs']) {
+            props.molecule.setAtomsDirty(true)
+            props.molecule.redraw(props.glRef)        
+        }
+
+    }, [bondWidth]);
+
+    useEffect(() => {
+        if (atomRadiusBondRatio === null) {
+            return
+        }
+        
+        props.molecule.cootBondsOptions.atomRadiusBondRatio = atomRadiusBondRatio
+        if (isVisible && showState['CBs']) {
+            props.molecule.setAtomsDirty(true)
+            props.molecule.redraw(props.glRef)        
+        }
+
+    }, [atomRadiusBondRatio]);
 
     useEffect(() => {
         const initialState = {}
@@ -164,23 +235,23 @@ export const BabyGruMoleculeCard = (props) => {
             }
         },
         6: {
-            label: 'Merge molecules',
-            compressed: () => { return (<BabyGruMergeMoleculesMenuItem key={6} glRef={props.glRef} molecules={props.molecules} setPopoverIsShown={setPopoverIsShown} menuItemText="Merge molecule into..." popoverPlacement='left' fromMolNo={props.molecule.molNo}/>) },
+            label: 'Refine selected residues',
+            compressed: () => { return (<MenuItem key={6} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleResidueRangeRefinement}>Refine selected residues</MenuItem>) },
             expanded: null
         },
         7: {
-            label: 'Refine selected residues',
-            compressed: () => { return (<MenuItem key={7} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleResidueRangeRefinement}>Refine selected residues</MenuItem>) },
+            label: 'Rename molecule',
+            compressed: () => { return (<BabyGruRenameDisplayObjectMenuItem key={7} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
             expanded: null
         },
         8: {
-            label: 'Rename molecule',
-            compressed: () => { return (<BabyGruRenameDisplayObjectMenuItem key={8} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
+            label: 'Copy selected residues into fragment',
+            compressed: () => { return (<MenuItem key={8} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>) },
             expanded: null
         },
         9: {
-            label: 'Copy selected residues into fragment',
-            compressed: () => { return (<MenuItem key={9} variant="success" disabled={(!clickedResidue || !selectedResidues)} onClick={handleCopyFragment}>Copy selected residues into fragment</MenuItem>) },
+            label: 'Display settings',
+            compressed: () => { return (<BabyGruMoleculeBondSettingsMenuItem key={9} setPopoverIsShown={setPopoverIsShown} molecule={props.molecule} {...bondSettingsProps}/>) },
             expanded: null
         },
     }

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -479,6 +479,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("get_rotamer_dodecs",&molecules_container_t::get_rotamer_dodecs)
     .function("auto_fit_rotamer",&molecules_container_t::auto_fit_rotamer)
     .function("cis_trans_convert",&molecules_container_t::cis_trans_convert)
+    .function("set_draw_missing_residue_loops",&molecules_container_t::set_draw_missing_residue_loops)
     .function("get_map_contours_mesh",&molecules_container_t::get_map_contours_mesh)
     .function("geometry_init_standard",&molecules_container_t::geometry_init_standard)
     .function("fill_rotamer_probability_tables",&molecules_container_t::fill_rotamer_probability_tables)

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -478,6 +478,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("get_ramachandran_validation_markup_mesh",&molecules_container_t::get_ramachandran_validation_markup_mesh)
     .function("get_rotamer_dodecs",&molecules_container_t::get_rotamer_dodecs)
     .function("auto_fit_rotamer",&molecules_container_t::auto_fit_rotamer)
+    .function("cis_trans_convert",&molecules_container_t::cis_trans_convert)
     .function("get_map_contours_mesh",&molecules_container_t::get_map_contours_mesh)
     .function("geometry_init_standard",&molecules_container_t::geometry_init_standard)
     .function("fill_rotamer_probability_tables",&molecules_container_t::fill_rotamer_probability_tables)

--- a/react-app/src/mgWebGL.js
+++ b/react-app/src/mgWebGL.js
@@ -883,6 +883,14 @@ var icosaIndices = icosaIndices2;
 
 var icosaNormals = icosaVertices;
 
+function isDarkBackground(r, g, b) {
+    const brightness = r * 0.299 + g * 0.587 + b * 0.114
+    if (brightness >= 0.5) {
+        return false
+    }
+    return true
+}
+
 function flatNormalMesh(vertices, indices) {
     var newVertices = [];
     var newNormals = [];
@@ -7898,10 +7906,10 @@ class MGWebGL extends Component {
         this.gl.uniform1f(this.shaderProgramTextBackground.maxTextureS, 1.0);
         let textTextureDirty = false;
         let textColour = "black";
-        const bright_y = this.background_colour[0] * 0.299 + this.background_colour[1] * 0.587 + this.background_colour[2] * 0.114;
-        if (bright_y < 0.5) {
+        if (isDarkBackground(...this.background_colour)) {
             textColour = "white";
-        }
+        } 
+        
         if (textColour !== this.previousTextColour) textTextureDirty = true;
         this.previousTextColour = textColour;
 
@@ -11084,4 +11092,4 @@ class MGWebGL extends Component {
     }
 }
 
-export { MGWebGL, icosaIndices1, icosaVertices1, icosaIndices2, icosaVertices2, getDeviceScale, vec3Create };
+export { MGWebGL, icosaIndices1, icosaVertices1, icosaIndices2, icosaVertices2, getDeviceScale, vec3Create, isDarkBackground };


### PR DESCRIPTION
This update includes:

- A fix for the "Edit" dropdown button which can now be dismissed by clicking outside the panel as long as the popover is not shown.
- A new item in the molecule card options dropdown to set the new coot bond options
- Merge molecules has been removed from the molecule card options dropdown as this is now included in the "Edit" menu.