### PR TITLE
Enable session download and upload

### DIFF
--- a/baby-gru/src/components/BabyGruFileMenu.js
+++ b/baby-gru/src/components/BabyGruFileMenu.js
@@ -152,7 +152,6 @@ export const BabyGruFileMenu = (props) => {
         glRef.current.background_colour = sessionData.backgroundColor
         glRef.current.setOrigin(sessionData.origin, false)
         glRef.current.setQuat(sessionData.quat4)
-
     }
 
     const downloadSession = async () => {

--- a/baby-gru/src/components/BabyGruFileMenu.js
+++ b/baby-gru/src/components/BabyGruFileMenu.js
@@ -3,6 +3,8 @@ import { BabyGruMolecule } from "../utils/BabyGruMolecule";
 import { BabyGruMap } from "../utils/BabyGruMap";
 import { useState, useRef } from "react";
 import { BabyGruImportDictionaryMenuItem, BabyGruImportMapCoefficientsMenuItem, BabyGruDeleteEverythingMenuItem, BabyGruLoadTutorialDataMenuItem, BabyGruImportMapMenuItem, BabyGruImportFSigFMenuItem } from "./BabyGruMenuItem";
+import { MenuItem } from "@mui/material";
+import { doDownload, readTextFile } from "../utils/BabyGruUtils";
 
 export const BabyGruFileMenu = (props) => {
 
@@ -100,6 +102,87 @@ export const BabyGruFileMenu = (props) => {
         }
     }
 
+    const loadSession = async (file) => {
+        // Load session data
+        let sessionData = await readTextFile(file)
+        sessionData = JSON.parse(sessionData)
+        console.log(sessionData)
+        
+        // Delete current scene
+        props.molecules.forEach(molecule => {
+            molecule.delete(props.glRef)
+        })
+        changeMolecules({ action: "Empty" })
+
+        // Load molecules stored in session from pdb string
+        let newMoleculePromises = [];
+        let newMolecule;
+        sessionData.moleculesPdbData.forEach((pdbData, index) => {
+            newMolecule = new BabyGruMolecule(commandCentre)
+            newMoleculePromises.push(
+                newMolecule.loadToCootFromString(pdbData, sessionData.moleculesNames[index])
+            )
+        })
+        let newMolecules = await Promise.all(newMoleculePromises)
+
+        // Draw the molecules with the styles stored in session
+        let drawPromises = []
+        newMolecules.forEach((molecule, moleculeIndex) => {
+            molecule.cootBondsOptions = sessionData.moleculesCootBondsOptions[moleculeIndex]
+            const styles = sessionData.moleculesDisplayObjectsKeys[moleculeIndex]
+            styles.forEach(style => drawPromises.push(molecule.fetchIfDirtyAndDraw(style, glRef, true)))
+        })
+        await Promise.all(drawPromises)
+        
+        // Change props.molecules
+        newMolecules.forEach(molecule => {
+            changeMolecules({ action: "Add", item: molecule })
+        })
+
+        // Set camera details
+        glRef.current.setAmbientLightNoUpdate(...Object.values(sessionData.ambientLight))
+        glRef.current.setSpecularLightNoUpdate(...Object.values(sessionData.specularLight))
+        glRef.current.setDiffuseLightNoUpdate(...Object.values(sessionData.diffuseLight))
+        glRef.current.setLightPositionNoUpdate(...Object.values(sessionData.lightPosition))
+        glRef.current.setZoom(sessionData.zoom, false)
+        glRef.current.set_fog_range(sessionData.fogStart, sessionData.fogEnd, false)
+        glRef.current.set_clip_range(sessionData.clipStart, sessionData.clipEnd, false)
+        glRef.current.doDrawClickedAtomLines = sessionData.doDrawClickedAtomLines
+        glRef.current.atomLabelDepthMode = sessionData.atomLabelDepthMode
+        glRef.current.background_colour = sessionData.backgroundColor
+        glRef.current.setOrigin(sessionData.origin, false)
+        glRef.current.setQuat(sessionData.quat4)
+
+    }
+
+    const downloadSession = async () => {
+        let promises = props.molecules.map(molecule => {return molecule.getAtoms()})
+        let response = await Promise.all(promises)
+
+        let session = {
+            moleculesNames: props.molecules.map(molecule => molecule.name),
+            moleculesPdbData: response.map(item => item.data.result.pdbData),
+            moleculesDisplayObjectsKeys: props.molecules.map(molecule => Object.keys(molecule.displayObjects).filter(key => molecule.displayObjects[key].length > 0)),
+            moleculesCootBondsOptions: props.molecules.map(molecule => molecule.cootBondsOptions),
+            origin: props.glRef.current.origin,
+            backgroundColor: props.backgroundColor,
+            atomLabelDepthMode: props.atomLabelDepthMode,
+            ambientLight: glRef.current.light_colours_ambient,
+            diffuseLight: glRef.current.light_colours_diffuse,
+            lightPosition: glRef.current.light_positions,
+            specularLight: glRef.current.light_colours_specular,
+            fogStart: glRef.current.gl_fog_start,
+            fogEnd: glRef.current.gl_fog_end,
+            zoom: glRef.current.zoom,
+            doDrawClickedAtomLines: glRef.current.doDrawClickedAtomLines,
+            clipStart: (glRef.current.gl_clipPlane0[3] + 500) * -1,
+            clipEnd: glRef.current.gl_clipPlane1[3] - 500,
+            quat4: glRef.current.myQuat
+        }
+
+        doDownload([JSON.stringify(session)], `session.json`)
+    }
+
     return <>
         <NavDropdown
             title="File"
@@ -134,6 +217,11 @@ export const BabyGruFileMenu = (props) => {
                 </InputGroup>
             </Form.Group>
 
+            <Form.Group style={{ width: '20rem', margin: '0.5rem' }} controlId="upload-session-form" className="mb-3">
+                <Form.Label>Load from stored session</Form.Label>
+                <Form.Control type="file" accept=".json" multiple={false} onChange={(e) => { loadSession(e.target.files[0]) }}/>
+            </Form.Group>
+
             <BabyGruImportMapCoefficientsMenuItem {...menuItemProps} />
 
             <BabyGruImportFSigFMenuItem {...menuItemProps} />
@@ -143,6 +231,10 @@ export const BabyGruFileMenu = (props) => {
             <BabyGruImportDictionaryMenuItem {...menuItemProps} />
 
             <BabyGruLoadTutorialDataMenuItem {...menuItemProps} />
+
+            <MenuItem id='download-session-menu-item' variant="success" onClick={downloadSession}>
+                Download session
+            </MenuItem>
 
             <BabyGruDeleteEverythingMenuItem {...menuItemProps} />
 

--- a/baby-gru/src/components/BabyGruLigandMenu.js
+++ b/baby-gru/src/components/BabyGruLigandMenu.js
@@ -16,7 +16,6 @@ export const BabyGruLigandMenu = (props) => {
             onToggle={() => { props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1) }}>
             <BabyGruGetMonomerMenuItem {...menuItemProps} />
             <BabyGruImportDictionaryMenuItem {...menuItemProps} />
-            <BabyGruMergeMoleculesMenuItem {...menuItemProps} />
             <BabyGruAddWatersMenuItem {...menuItemProps} />
         </NavDropdown>
     </>

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -182,7 +182,7 @@ export const BabyGruMoleculeCard = (props) => {
     }
 
     const handleProps = { handleCentering, handleCopyFragment, handleDownload, handleRedo, handleUndo, handleResidueRangeRefinement, handleVisibility}
-    const ligandList = props.molecule.getLigands()
+    //const ligandList = props.molecule.getLigands()
 
     return <Card className="px-0" style={{ marginBottom: '0.5rem', padding: '0' }} key={props.molecule.molNo}>
         <Card.Header>

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useState, useMemo } from "react";
-import { Card, Form, Row, Col } from "react-bootstrap";
+import React, { useEffect, useState } from "react";
+import { Card, Form, Row, Col, Button } from "react-bootstrap";
 import { doDownload, sequenceIsValid } from '../utils/BabyGruUtils';
 import { isDarkBackground } from '../WebGL/mgWebGL'
 import { BabyGruSequenceViewer } from "./BabyGruSequenceViewer";
@@ -182,13 +182,13 @@ export const BabyGruMoleculeCard = (props) => {
     }
 
     const handleProps = { handleCentering, handleCopyFragment, handleDownload, handleRedo, handleUndo, handleResidueRangeRefinement, handleVisibility}
+    const ligandList = props.molecule.getLigands()
 
     return <Card className="px-0" style={{ marginBottom: '0.5rem', padding: '0' }} key={props.molecule.molNo}>
         <Card.Header>
             <Row className='align-items-center'>
             <Col className='align-items-center' style={{display:'flex', justifyContent:'left'}}>
                     {`#${props.molecule.molNo} Mol. ${props.molecule.name}`}
-                    <img className="baby-gru-map-icon" alt="..." src= "/baby-gru/pixmaps/secondary-structure.svg" style={{width: '20px', height: '20px', margin:'0.5rem', padding:'0'}}/>
                 </Col>
                 <Col style={{ display: 'flex', justifyContent: 'right' }}>
                     <BabyGruMoleculeCardButtonBar
@@ -300,6 +300,32 @@ export const BabyGruMoleculeCard = (props) => {
                     }
                 </Col>
             </Row>
+            {/**props.molecule.ligands?.length > 0 && 
+                <>
+                    <hr></hr>
+                    <Row style={{ height: '100%' }}>
+                        <Col>
+                            <div>
+                                <b>Ligands</b>
+                            </div>
+                            <Card style={{margin: '0.5rem'}}>
+                                <Card.Body>
+                                    <Row style={{display:'flex', justifyContent:'between'}}>
+                                        <Col style={{alignItems:'center', justifyContent:'left', display:'flex'}}>
+                                            {"flip.buttonLabel"}
+                                        </Col>
+                                        <Col className='col-3' style={{margin: '0', padding:'0', justifyContent: 'right', display:'flex'}}>
+                                            <Button>
+                                                View
+                                            </Button>
+                                        </Col>
+                                    </Row>
+                                </Card.Body>
+                            </Card>
+                        </Col>
+                    </Row>
+                </>
+            */}
         </Card.Body>
     </Card >
 }

--- a/baby-gru/src/utils/BabyGruMolecule.js
+++ b/baby-gru/src/utils/BabyGruMolecule.js
@@ -100,6 +100,27 @@ BabyGruMolecule.prototype.loadToCootFromFile = function (source) {
         })
 }
 
+BabyGruMolecule.prototype.loadToCootFromString = async function (coordData, name) {
+    const $this = this
+    const pdbRegex = /.pdb$/;
+    const entRegex = /.ent$/;
+
+    $this.name = name.replace(pdbRegex, "").replace(entRegex, "");
+    $this.cachedAtoms = $this.webMGAtomsFromFileString(coordData)
+    $this.atomsDirty = false
+
+    let response  = await this.commandCentre.current.cootCommand({
+        returnType: "status",
+        command: 'shim_read_pdb',
+        commandArgs: [coordData, $this.name],
+        changesMolecules: [$this.molNo]
+    }, true)
+
+    $this.molNo = response.data.result.result
+    return Promise.resolve($this)
+
+}
+
 BabyGruMolecule.prototype.setAtomsDirty = function (state) {
     this.atomsDirty = state
 }


### PR DESCRIPTION
After this update it becomes possible to store a session in the form of a json file. That json file can then be uploaded to re-store the session (includes molecule representation and camera details). This does not include map data yet, this will come in future updates.