### PR TITLE
Add gemmi structure to BabyGruMolecule

### DIFF
--- a/baby-gru/src/utils/BabyGruMolecule.js
+++ b/baby-gru/src/utils/BabyGruMolecule.js
@@ -44,7 +44,7 @@ export function BabyGruMolecule(commandCentre) {
 
 BabyGruMolecule.prototype.updateGemmiStructure = async function () {
     let response = await this.getAtoms()
-    this.gemmiStructure = readGemmiStructure(response.data.result.pdbData)
+    this.gemmiStructure = readGemmiStructure(response.data.result.pdbData, this.name)
 }
 
 
@@ -92,7 +92,7 @@ BabyGruMolecule.prototype.loadToCootFromFile = function (source) {
         .then(coordData => {
             $this.name = source.name.replace(pdbRegex, "").replace(entRegex, "");
             $this.cachedAtoms = $this.webMGAtomsFromFileString(coordData)
-            $this.gemmiStructure = readGemmiStructure(coordData)
+            $this.gemmiStructure = readGemmiStructure(coordData, $this.name)
             $this.atomsDirty = false
             return this.commandCentre.current.cootCommand({
                 returnType: "status",
@@ -114,7 +114,7 @@ BabyGruMolecule.prototype.loadToCootFromString = async function (coordData, name
 
     $this.name = name.replace(pdbRegex, "").replace(entRegex, "");
     $this.cachedAtoms = $this.webMGAtomsFromFileString(coordData)
-    $this.gemmiStructure = readGemmiStructure(coordData)
+    $this.gemmiStructure = readGemmiStructure(coordData, $this.name)
     $this.atomsDirty = false
 
     let response  = await this.commandCentre.current.cootCommand({
@@ -143,7 +143,7 @@ BabyGruMolecule.prototype.loadToCootFromURL = function (url, molName) {
         }).then((coordData) => {
             $this.name = molName
             $this.cachedAtoms = $this.webMGAtomsFromFileString(coordData)
-            $this.gemmiStructure = readGemmiStructure(coordData)
+            $this.gemmiStructure = readGemmiStructure(coordData, $this.name)
             $this.atomsDirty = false
 
             return this.commandCentre.current.cootCommand({
@@ -173,7 +173,7 @@ BabyGruMolecule.prototype.updateAtoms = function () {
     return $this.getAtoms().then((result) => {
         return new Promise((resolve, reject) => {
             $this.cachedAtoms = $this.webMGAtomsFromFileString(result.data.result.pdbData)
-            $this.gemmiStructure = readGemmiStructure(result.data.result.pdbData)
+            $this.gemmiStructure = readGemmiStructure(result.data.result.pdbData, $this.name)
             $this.atomsDirty = false
             resolve($this.cachedAtoms)
         })

--- a/baby-gru/src/utils/BabyGruMolecule.js
+++ b/baby-gru/src/utils/BabyGruMolecule.js
@@ -6,7 +6,7 @@ import { GetSplinesColoured } from '../WebGL/mgSecStr';
 import { atomsToSpheresInfo } from '../WebGL/mgWebGLAtomsToPrimitives';
 import { contactsToCylindersInfo, contactsToLinesInfo } from '../WebGL/mgWebGLAtomsToPrimitives';
 import { singletonsToLinesInfo } from '../WebGL/mgWebGLAtomsToPrimitives';
-import { readTextFile } from '../utils/BabyGruUtils'
+import { readTextFile, readGemmiStructure } from '../utils/BabyGruUtils'
 import { quatToMat4 } from '../WebGL/quatToMat4.js';
 import * as vec3 from 'gl-matrix/vec3';
 
@@ -19,6 +19,7 @@ export function BabyGruMolecule(commandCentre) {
     this.atomsDirty = true
     this.name = "unnamed"
     this.molNo = null
+    this.gemmiStructure = null
     this.cootBondsOptions = {
         isDarkBackground: false,
         smoothness: 1,
@@ -40,6 +41,11 @@ export function BabyGruMolecule(commandCentre) {
         transformation: { origin: [0, 0, 0], quat: null, centre: [0, 0, 0] }
     }
 };
+
+BabyGruMolecule.prototype.updateGemmiStructure = async function () {
+    let response = await this.getAtoms()
+    this.gemmiStructure = readGemmiStructure(response.data.result.pdbData)
+}
 
 
 BabyGruMolecule.prototype.delete = async function (glRef) {
@@ -86,6 +92,7 @@ BabyGruMolecule.prototype.loadToCootFromFile = function (source) {
         .then(coordData => {
             $this.name = source.name.replace(pdbRegex, "").replace(entRegex, "");
             $this.cachedAtoms = $this.webMGAtomsFromFileString(coordData)
+            $this.gemmiStructure = readGemmiStructure(coordData)
             $this.atomsDirty = false
             return this.commandCentre.current.cootCommand({
                 returnType: "status",
@@ -107,6 +114,7 @@ BabyGruMolecule.prototype.loadToCootFromString = async function (coordData, name
 
     $this.name = name.replace(pdbRegex, "").replace(entRegex, "");
     $this.cachedAtoms = $this.webMGAtomsFromFileString(coordData)
+    $this.gemmiStructure = readGemmiStructure(coordData)
     $this.atomsDirty = false
 
     let response  = await this.commandCentre.current.cootCommand({
@@ -135,6 +143,7 @@ BabyGruMolecule.prototype.loadToCootFromURL = function (url, molName) {
         }).then((coordData) => {
             $this.name = molName
             $this.cachedAtoms = $this.webMGAtomsFromFileString(coordData)
+            $this.gemmiStructure = readGemmiStructure(coordData)
             $this.atomsDirty = false
 
             return this.commandCentre.current.cootCommand({
@@ -164,6 +173,7 @@ BabyGruMolecule.prototype.updateAtoms = function () {
     return $this.getAtoms().then((result) => {
         return new Promise((resolve, reject) => {
             $this.cachedAtoms = $this.webMGAtomsFromFileString(result.data.result.pdbData)
+            $this.gemmiStructure = readGemmiStructure(result.data.result.pdbData)
             $this.atomsDirty = false
             resolve($this.cachedAtoms)
         })

--- a/baby-gru/src/utils/BabyGruUtils.js
+++ b/baby-gru/src/utils/BabyGruUtils.js
@@ -145,6 +145,14 @@ export const doDownloadText = (text, filename) => {
     document.body.removeChild(element);
 }
 
+export const readGemmiStructure = async (pdbData) => {
+    const fileName = `File_${uuidv4()}`
+    window.CCP4Module.FS_createDataFile(".", fileName, pdbData, true, true);
+    const structure = window.CCP4Module.read_structure_file(`./${fileName}`, window.CCP4Module.CoorFormat.Pdb)
+    window.CCP4Module.FS_unlink(`./${fileName}`)
+    return structure
+}
+
 export const BabyGruCommandCentre = class {
     banana = 12
     consoleMessage = ""

--- a/baby-gru/src/utils/BabyGruUtils.js
+++ b/baby-gru/src/utils/BabyGruUtils.js
@@ -145,11 +145,8 @@ export const doDownloadText = (text, filename) => {
     document.body.removeChild(element);
 }
 
-export const readGemmiStructure = async (pdbData) => {
-    const fileName = `File_${uuidv4()}`
-    window.CCP4Module.FS_createDataFile(".", fileName, pdbData, true, true);
-    const structure = window.CCP4Module.read_structure_file(`./${fileName}`, window.CCP4Module.CoorFormat.Pdb)
-    window.CCP4Module.FS_unlink(`./${fileName}`)
+export const readGemmiStructure = async (pdbData, molName) => {
+    const structure = window.CCP4Module.read_structure_from_string(pdbData, molName)
     return structure
 }
 


### PR DESCRIPTION
After this update, `BabyGruMolecule` has a new attribute `gemmiStructure` that stores a `gemmi::Structure`. This gemmi instance is updated inside the method `BabyGruMolecule.updateAtoms` along with `BabyGruMolecule.cachedAtoms`. This means these two attributes should always contain data matching the same molecule (always up to date).