### PR TITLE
Simplify UI to connect updating maps

### DIFF
--- a/baby-gru/src/components/BabyGruDifferenceMapPeaks.js
+++ b/baby-gru/src/components/BabyGruDifferenceMapPeaks.js
@@ -290,7 +290,7 @@ export const BabyGruDifferenceMapPeaks = (props) => {
                                 <BabyGruMoleculeSelect width="" onChange={handleModelChange} molecules={props.molecules} ref={moleculeSelectRef}/>
                             </Col>
                             <Col>
-                                <BabyGruMapSelect onlyDifferenceMaps={true} width="" onChange={handleMapChange} maps={props.maps} ref={mapSelectRef}/>
+                                <BabyGruMapSelect filterFunction={(map) => map.isDifference} width="" onChange={handleMapChange} maps={props.maps} ref={mapSelectRef}/>
                             </Col>
                             <Col style={{justifyContent:'center', alignContent:'center', alignItems:'center', display:'flex'}}>
                                 <Form.Group controlId="rmsdSlider" style={{margin:'0.5rem', width: '100%'}}>

--- a/baby-gru/src/components/BabyGruLigandList.js
+++ b/baby-gru/src/components/BabyGruLigandList.js
@@ -39,7 +39,6 @@ export const BabyGruLigandList = (props) => {
     return <>
             {ligandList.length > 0 ? 
                 <>
-                    <hr></hr>
                     <Row style={{ height: '100%' }}>
                         <Col>
                             {ligandList.map(ligand => {

--- a/baby-gru/src/components/BabyGruMapSelect.js
+++ b/baby-gru/src/components/BabyGruMapSelect.js
@@ -14,10 +14,9 @@ export const BabyGruMapSelect = forwardRef((props, selectRef) => {
         
         if (props.maps) {
             props.maps.forEach(map => {
-                if(props.onlyDifferenceMaps && !map.isDifference){
-                    return
+                if(props.filterFunction(map)){
+                    mapOptions.push(<option key={map.molNo} value={map.molNo}>{map.molNo}: {map.name}</option>)
                 }
-                mapOptions.push(<option key={map.molNo} value={map.molNo}>{map.molNo}: {map.name}</option>)
             })
         }
 
@@ -32,4 +31,4 @@ export const BabyGruMapSelect = forwardRef((props, selectRef) => {
     </Form.Group>
 })
 
-BabyGruMapSelect.defaultProps = { height: '4rem', width: '20rem', maps: null, label: "Map", onlyDifferenceMaps:false }
+BabyGruMapSelect.defaultProps = { height: '4rem', width: '20rem', maps: null, label: "Map", filterFunction: () => true }

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -2,7 +2,7 @@ import { MenuItem } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { OverlayTrigger, Popover, PopoverBody, PopoverHeader, Form, InputGroup, Button, FormSelect, Row, Col, SplitButton, Dropdown } from "react-bootstrap";
 import { SketchPicker } from "react-color";
-import { BabyGruMtzWrapper, readDataFile, readTextFile } from "../utils/BabyGruUtils";
+import { BabyGruMtzWrapper, readTextFile } from "../utils/BabyGruUtils";
 import { BabyGruMap } from "../utils/BabyGruMap";
 import { BabyGruMolecule } from "../utils/BabyGruMolecule";
 import { BabyGruMoleculeSelect } from "./BabyGruMoleculeSelect";
@@ -585,12 +585,6 @@ export const BabyGruImportMapCoefficientsMenuItem = (props) => {
     const handleFile = async (file, selectedColumns) => {
         const newMap = new BabyGruMap(props.commandCentre)
         await newMap.loadToCootFromMtzFile(file, selectedColumns)
-        if (selectedColumns.calcStructFact) {
-            const reflectionData = await readDataFile(file)
-            const asUIntArray = new Uint8Array(reflectionData)
-            await newMap.associateToReflectionData(selectedColumns, asUIntArray)
-            newMap.hasReflectionData = true
-        }
         props.changeMaps({ action: 'Add', item: newMap })
         props.setActiveMap(newMap)
         setCalcStructFact(false)

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -96,7 +96,8 @@ export const BabyGruLoadTutorialDataMenuItem = (props) => {
                 newMolecule.centreOn(props.glRef)
             }).then(_ => {
                 return newMap.loadToCootFromMtzURL(`/baby-gru/tutorials/moorhen-tutorial-map-number-${tutorialNumber}.mtz`, `moorhen-tutorial-${tutorialNumber}`,
-                    { F: "FWT", PHI: "PHWT", isDifference: false, useWeight: false })
+                    { F: "FWT", PHI: "PHWT", Fobs: tutorialNumber == 1 ? 'F' : 'FP', SigFobs: tutorialNumber == 1 ? 'SIGF' : 'SIGFP', FreeR: 'FREER',
+                     isDifference: false, useWeight: false, calcStructFact: true })
             }).then(_ => {
                 return newDiffMap.loadToCootFromMtzURL(`/baby-gru/tutorials/moorhen-tutorial-map-number-${tutorialNumber}.mtz`, `moorhen-tutorial-${tutorialNumber}`,
                     { F: "DELFWT", PHI: "PHDELWT", isDifference: true, useWeight: false })

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -1,4 +1,4 @@
-import { Divider, Menu, MenuItem, Modal } from "@mui/material";
+import { MenuItem } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { OverlayTrigger, Popover, PopoverBody, PopoverHeader, Form, InputGroup, Button, FormSelect, Row, Col, SplitButton, Dropdown } from "react-bootstrap";
 import { SketchPicker } from "react-color";
@@ -10,7 +10,6 @@ import BabyGruSlider from "./BabyGruSlider";
 import { BabyGruMapSelect } from "./BabyGruMapSelect";
 import "rc-tree/assets/index.css"
 import Tree from 'rc-tree';
-import { FolderOpen } from "@mui/icons-material";
 
 export const BabyGruMenuItem = (props) => {
 
@@ -565,44 +564,43 @@ export const BabyGruImportDictionaryMenuItem = (props) => {
 
 export const BabyGruImportMapCoefficientsMenuItem = (props) => {
     const filesRef = useRef(null)
-    const fSelectRef = useRef()
-    const phiSelectRef = useRef()
-    const wSelectRef = useRef()
-    const isDiffRef = useRef()
-    const useWeightRef = useRef()
+    const fSelectRef = useRef(null)
+    const phiSelectRef = useRef(null)
+    const wSelectRef = useRef(null)
+    const sigFobsSelectRef = useRef(null)
+    const fobsSelectRef = useRef(null)
+    const freeRSelectRef = useRef(null)
+    const isDiffRef = useRef(null)
+    const useWeightRef = useRef(null)
+    const calcStructFactRef = useRef(null)
+    const [calcStructFact, setCalcStructFact] = useState(false)
     const [columns, setColumns] = useState({})
 
     const handleFileRead = async (e) => {
-        const newMap = new BabyGruMap(props.commandCentre)
         const babyGruMtzWrapper = new BabyGruMtzWrapper()
-        const newColumns = await babyGruMtzWrapper.loadHeaderFromFile(e.target.files[0])
-        const fColumns = Object.keys(newColumns)
-            .filter(key => newColumns[key] === 'F')
-        const pColumns = Object.keys(newColumns)
-            .filter(key => newColumns[key] === 'P')
-        const wColumns = Object.keys(newColumns)
-            .filter(key => newColumns[key] === 'W')
-        if (fColumns.length === 1 && fColumns.includes('FWT') &&
-            pColumns.length === 1 && pColumns.includes('PHWT')) {
-            let selectedColumns = { F: 'FWT', PHI: 'PHWT', W: '', isDifference: false, useWeight: false }
-            await handleFile(e.target.files[0], selectedColumns)
-        }
-        else {
-            setColumns(newColumns)
-        }
+        let allColumnNames = await babyGruMtzWrapper.loadHeaderFromFile(e.target.files[0])
+        setColumns(allColumnNames)
     }
 
     const handleFile = async (file, selectedColumns) => {
         const newMap = new BabyGruMap(props.commandCentre)
         await newMap.loadToCootFromMtzFile(file, selectedColumns)
+        if (selectedColumns.calcStructFact) {
+            const reflectionData = await readDataFile(file)
+            const asUIntArray = new Uint8Array(reflectionData)
+            await newMap.associateToReflectionData(selectedColumns, asUIntArray)
+        }
         props.changeMaps({ action: 'Add', item: newMap })
         props.setActiveMap(newMap)
+        setCalcStructFact(false)
     }
 
     const onCompleted = async () => {
         let selectedColumns = {
             F: fSelectRef.current.value, PHI: phiSelectRef.current.value, W: wSelectRef.current.value,
-            isDifference: isDiffRef.current.checked, useWeight: useWeightRef.current.checked
+            isDifference: isDiffRef.current.checked, useWeight: useWeightRef.current.checked,
+            Fobs: fobsSelectRef.current.value, SigFobs: sigFobsSelectRef.current.value,
+            FreeR: freeRSelectRef.current.value, calcStructFact: calcStructFactRef.current.checked
         }
         props.setPopoverIsShown(false)
         return await handleFile(filesRef.current.files[0], selectedColumns)
@@ -610,7 +608,7 @@ export const BabyGruImportMapCoefficientsMenuItem = (props) => {
 
     const panelContent = <>
         <Row>
-            <Form.Group style={{ width: '30rem', margin: '0.5rem' }} controlId="uploadDicts" className="mb-3">
+            <Form.Group style={{ width: '30rem', margin: '0.5rem', padding: '0rem'}} controlId="uploadDicts" className="mb-3">
                 <Form.Label>Map coefficient files</Form.Label>
                 <Form.Control ref={filesRef} type="file" multiple={false} accept={[".mtz"]} onChange={(e) => {
                     handleFileRead(e)
@@ -653,6 +651,44 @@ export const BabyGruImportMapCoefficientsMenuItem = (props) => {
             <Col>
                 <Form.Check label={'use weight'} name={`useWeight`} type="checkbox" ref={useWeightRef} variant="outline" />
             </Col>
+            <Row key="Row4" style={{ marginTop: "1rem" }}>
+            <Col>
+                <Form.Check ref={calcStructFactRef} label={'assing labels for structure factor calculation?'} name={`calcStructFactors`} type="checkbox" variant="outline"
+                    onChange={() => setCalcStructFact(
+                        (prev) => {return !prev}
+                    )} 
+                />
+            </Col>
+        </Row>            
+        </Row>
+        <Row key="Row3" style={{ marginBottom: "1rem" }}>
+            <Col key="F">
+                Fobs
+                <FormSelect size="sm" disabled={!calcStructFactRef.current?.checked} ref={fobsSelectRef} defaultValue="FP" onChange={(val) => { }}>
+                    {Object.keys(columns)
+                        .filter(key => columns[key] === 'F')
+                        .map(key => <option value={key} key={key}>{key}</option>
+                        )}
+                </FormSelect>
+            </Col>
+            <Col key="SigF">
+                SIGFobs
+                <FormSelect size="sm" disabled={!calcStructFactRef.current?.checked} ref={sigFobsSelectRef} defaultValue="SIGFP" onChange={(val) => { }}>
+                    {Object.keys(columns)
+                        .filter(key => columns[key] === 'Q')
+                        .map(key => <option value={key} key={key}>{key}</option>
+                        )}
+                </FormSelect>
+            </Col>
+            <Col key="FreeR">
+                Free R
+                <FormSelect size="sm" disabled={!calcStructFactRef.current?.checked} ref={freeRSelectRef} defaultValue="FREER" onChange={(val) => { }}>
+                    {Object.keys(columns)
+                        .filter(key => columns[key] === 'I')
+                        .map(key => <option value={key} key={key}>{key}</option>
+                        )}
+                </FormSelect>
+            </Col>
         </Row>
     </>
 
@@ -666,133 +702,50 @@ export const BabyGruImportMapCoefficientsMenuItem = (props) => {
 }
 
 export const BabyGruImportFSigFMenuItem = (props) => {
-    const filesRef = useRef(null)
-    const fSelectRef = useRef()
-    const sigFSelectRef = useRef()
-    const freeRSelectRef = useRef()
     const mapSelectRef = useRef()
     const twoFoFcSelectRef = useRef()
     const foFcSelectRef = useRef()
     const moleculeSelectRef = useRef()
-    const [columns, setColumns] = useState({})
 
-    const handleFileRead = async (e) => {
-        const babyGruMtzWrapper = new BabyGruMtzWrapper()
-        const newColumns = await babyGruMtzWrapper.loadHeaderFromFile(e.target.files[0])
-        const fColumns = Object.keys(newColumns)
-            .filter(key => newColumns[key] === 'F')
-        const sigFColumns = Object.keys(newColumns)
-            .filter(key => newColumns[key] === 'Q')
-        const freeRColumns = Object.keys(newColumns)
-            .filter(key => newColumns[key] === 'I')
-        if (fColumns.length === 1 && sigFColumns.length === 1 && freeRColumns.length === 1) {
-            let selectedColumns = { F: fColumns[0], SigF: sigFColumns[0], FreeR: freeRColumns[0] }
-            await handleFile(e.target.files[0], selectedColumns)
-        }
-        else {
-            setColumns(newColumns)
-        }
-    }
-
-    const handleFile = async (source, selectedColumns) => {
-        const $this = this
-        const reflectionData = await readDataFile(source)
-        const asUIntArray = new Uint8Array(reflectionData)
-
-        const commandArgs = [selectedColumns.iMol, { name: source.name, data: asUIntArray },
-        selectedColumns.F, selectedColumns.SigF, selectedColumns.FreeR]
-        console.log(commandArgs)
-        const result = props.commandCentre.current.cootCommand({
-            command: 'shim_associate_data_mtz_file_with_map',
-            commandArgs: commandArgs,
-            returnType: 'status'
-        }, true).then(result => {
-            const commandArgs = [
+    const connectMap = async () => {       
+        const commandArgs = [
                 moleculeSelectRef.current.value,
                 mapSelectRef.current.value,
                 twoFoFcSelectRef.current.value,
                 foFcSelectRef.current.value,
-            ]
-            props.commandCentre.current.cootCommand({
+        ]
+        await props.commandCentre.current.cootCommand({
                 command: 'connect_updating_maps',
                 commandArgs: commandArgs,
                 returnType: 'status'
-            }, true)
-        })
+        }, true)
     }
 
     const onCompleted = async () => {
-        console.log({ F: fSelectRef.current.value, })
-        console.log({ SigF: sigFSelectRef.current.value, })
-        console.log({ FreeR: freeRSelectRef.current.value, })
-        console.log({ iMol: mapSelectRef.current.value })
-        let selectedColumns = {
-            F: fSelectRef.current.value,
-            SigF: sigFSelectRef.current.value,
-            FreeR: freeRSelectRef.current.value,
-            iMol: mapSelectRef.current.value
-        }
         props.setPopoverIsShown(false)
-        return await handleFile(filesRef.current.files[0], selectedColumns)
+        return await connectMap()
     }
 
     const panelContent = <>
         <Row>
-            <Form.Group style={{ width: '30rem', margin: '0.5rem' }} controlId="uploadDicts" className="mb-3">
-                <Form.Label>FP, SIGFP file</Form.Label>
-                <Form.Control ref={filesRef} type="file" multiple={false} accept={[".mtz"]} onChange={(e) => {
-                    handleFileRead(e)
-                }} />
-            </Form.Group>
-        </Row>
-        <Row key="Row1" style={{ marginBottom: "1rem" }}>
-            <Col key="F">
-                FP
-                <FormSelect size="sm" ref={fSelectRef} defaultValue="F" onChange={(val) => { }}>
-                    {Object.keys(columns)
-                        .filter(key => columns[key] === 'F')
-                        .map(key => <option value={key} key={key}>{key}</option>
-                        )}
-                </FormSelect>
-            </Col>
-            <Col key="SigF">
-                SIGFP
-                <FormSelect size="sm" ref={sigFSelectRef} defaultValue="SIGF" onChange={(val) => { }}>
-                    {Object.keys(columns)
-                        .filter(key => columns[key] === 'Q')
-                        .map(key => <option value={key} key={key}>{key}</option>
-                        )}
-                </FormSelect>
-            </Col>
-            <Col key="FreeR">
-                Free R
-                <FormSelect size="sm" ref={freeRSelectRef} defaultValue="FREER" onChange={(val) => { }}>
-                    {Object.keys(columns)
-                        .filter(key => columns[key] === 'I')
-                        .map(key => <option value={key} key={key}>{key}</option>
-                        )}
-                </FormSelect>
-            </Col>
-        </Row>
-        <Row style={{ marginBottom: "1rem" }}>
-            <BabyGruMapSelect {...props} ref={mapSelectRef} allowAny={false} />
+            <BabyGruMapSelect {...props} ref={mapSelectRef} allowAny={false} width='30rem' />
         </Row>
         <Row style={{ marginBottom: "1rem" }}>
             <Col key="Col1">
-                <BabyGruMapSelect {...props} ref={twoFoFcSelectRef} label="2foFc" allowAny={false} />
+                <BabyGruMapSelect {...props} ref={twoFoFcSelectRef} label="2foFc" allowAny={false} width='100%' />
             </Col>
             <Col key="Col2">
-                <BabyGruMapSelect {...props} ref={foFcSelectRef} label="FoFc" onlyDifferenceMaps={true} allowAny={false} />
+                <BabyGruMapSelect {...props} ref={foFcSelectRef} label="FoFc" onlyDifferenceMaps={true} allowAny={false} width='100%' />
             </Col>
             <Col key="Col3">
-                <BabyGruMoleculeSelect {...props} ref={moleculeSelectRef} label="Molecule for phases" allowAny={false} />
+                <BabyGruMoleculeSelect {...props} ref={moleculeSelectRef} label="Molecule" allowAny={false} width='100%' />
             </Col>
         </Row>
     </>
 
     return <BabyGruMenuItem
         popoverContent={panelContent}
-        menuItemText="FP, SIGFP for map updating..."
+        menuItemText="Connect map and molecule for updating..."
         onCompleted={onCompleted}
         setPopoverIsShown={props.setPopoverIsShown}
     />
@@ -804,7 +757,7 @@ export const BabyGruImportMapMenuItem = (props) => {
 
     const panelContent = <>
         <Row>
-            <Form.Group style={{ width: '30rem', margin: '0.5rem' }} controlId="uploadDicts" className="mb-3">
+            <Form.Group style={{ width: '30rem', margin: '0.5rem', padding:'0rem' }} controlId="uploadCCP4Map" className="mb-3">
                 <Form.Label>CCP4/MRC Map...</Form.Label>
                 <Form.Control ref={filesRef} type="file" multiple={false} accept={[".map", ".mrc"]} onChange={(e) => {
                     handleFileRead(e)

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -96,7 +96,7 @@ export const BabyGruLoadTutorialDataMenuItem = (props) => {
                 newMolecule.centreOn(props.glRef)
             }).then(_ => {
                 return newMap.loadToCootFromMtzURL(`/baby-gru/tutorials/moorhen-tutorial-map-number-${tutorialNumber}.mtz`, `moorhen-tutorial-${tutorialNumber}`,
-                    { F: "FWT", PHI: "PHWT", Fobs: tutorialNumber == 1 ? 'F' : 'FP', SigFobs: tutorialNumber == 1 ? 'SIGF' : 'SIGFP', FreeR: 'FREER',
+                    { F: "FWT", PHI: "PHWT", Fobs: tutorialNumber == 1 ? 'F' : 'FP', SigFobs: tutorialNumber == 1 ? 'SIGF' : 'SIGFP', FreeR: tutorialNumber == 1 ? 'FREER' : 'FREE',
                      isDifference: false, useWeight: false, calcStructFact: true })
             }).then(_ => {
                 return newDiffMap.loadToCootFromMtzURL(`/baby-gru/tutorials/moorhen-tutorial-map-number-${tutorialNumber}.mtz`, `moorhen-tutorial-${tutorialNumber}`,

--- a/baby-gru/src/components/BabyGruMenuItem.js
+++ b/baby-gru/src/components/BabyGruMenuItem.js
@@ -589,6 +589,7 @@ export const BabyGruImportMapCoefficientsMenuItem = (props) => {
             const reflectionData = await readDataFile(file)
             const asUIntArray = new Uint8Array(reflectionData)
             await newMap.associateToReflectionData(selectedColumns, asUIntArray)
+            newMap.hasReflectionData = true
         }
         props.changeMaps({ action: 'Add', item: newMap })
         props.setActiveMap(newMap)
@@ -728,14 +729,16 @@ export const BabyGruImportFSigFMenuItem = (props) => {
 
     const panelContent = <>
         <Row>
-            <BabyGruMapSelect {...props} ref={mapSelectRef} allowAny={false} width='30rem' />
+            <Col style={{width:'30rem'}}>
+                <BabyGruMapSelect {...props} ref={mapSelectRef} filterFunction={(map) => map.hasReflectionData} allowAny={false} width='100%' label='Reflection data' />
+            </Col>
         </Row>
         <Row style={{ marginBottom: "1rem" }}>
             <Col key="Col1">
                 <BabyGruMapSelect {...props} ref={twoFoFcSelectRef} label="2foFc" allowAny={false} width='100%' />
             </Col>
             <Col key="Col2">
-                <BabyGruMapSelect {...props} ref={foFcSelectRef} label="FoFc" onlyDifferenceMaps={true} allowAny={false} width='100%' />
+                <BabyGruMapSelect {...props} ref={foFcSelectRef} label="FoFc" filterFunction={(map) => map.isDifference} allowAny={false} width='100%' />
             </Col>
             <Col key="Col3">
                 <BabyGruMoleculeSelect {...props} ref={moleculeSelectRef} label="Molecule" allowAny={false} width='100%' />

--- a/baby-gru/src/components/BabyGruMoleculeCard.js
+++ b/baby-gru/src/components/BabyGruMoleculeCard.js
@@ -212,7 +212,7 @@ export const BabyGruMoleculeCard = (props) => {
             </Row>
         </Card.Header>
         <Card.Body style={{ display: isCollapsed ? 'none' : '' }}>
-            <Accordion  alwaysOpen={true} defaultActiveKey={''}>
+            <Accordion  alwaysOpen={true} defaultActiveKey={['displayOpytions', 'sequences']}>
 
                 <Accordion.Item eventKey="displayOpytions" style={{ padding: '0', margin: '0' }} >
                     <Accordion.Header style={{ padding: '0', margin: '0' }}>Display Options</Accordion.Header>

--- a/baby-gru/src/components/BabyGruPepflipsDifferenceMap.js
+++ b/baby-gru/src/components/BabyGruPepflipsDifferenceMap.js
@@ -175,7 +175,7 @@ export const BabyGruPepflipsDifferenceMap = (props) => {
                                 <BabyGruMoleculeSelect width="" onChange={handleModelChange} molecules={props.molecules} ref={moleculeSelectRef}/>
                             </Col>
                             <Col>
-                                <BabyGruMapSelect onlyDifferenceMaps={true} width="" onChange={handleMapChange} maps={props.maps} ref={mapSelectRef}/>
+                                <BabyGruMapSelect filterFunction={(map) => map.isDifference} width="" onChange={handleMapChange} maps={props.maps} ref={mapSelectRef}/>
                             </Col>
                             <Col style={{justifyContent:'center', alignContent:'center', alignItems:'center', display:'flex'}}>
                                 <Form.Group controlId="rmsdSlider" style={{margin:'0.5rem', width: '100%'}}>

--- a/baby-gru/src/utils/BabyGruMap.js
+++ b/baby-gru/src/utils/BabyGruMap.js
@@ -253,3 +253,21 @@ BabyGruMap.prototype.doCootContour = function (glRef, x, y, z, radius, contourLe
 
 }
 
+BabyGruMap.prototype.associateToReflectionData = async function (selectedColumns, reflectionData) {
+    if (!selectedColumns.Fobs || !selectedColumns.SigFobs || !selectedColumns.FreeR) {
+        return Promise.reject('Missing column data')
+    }
+    let commandArgs = [
+        this.molNo, { name: this.name, data: reflectionData },
+        selectedColumns.Fobs, selectedColumns.SigFobs, selectedColumns.FreeR
+    ]
+
+    let result = await this.commandCentre.current.cootCommand({
+        command: 'shim_associate_data_mtz_file_with_map',
+        commandArgs: commandArgs,
+        returnType: 'status'
+    }, true)
+
+    return result
+}
+

--- a/baby-gru/src/utils/BabyGruMap.js
+++ b/baby-gru/src/utils/BabyGruMap.js
@@ -13,6 +13,7 @@ export function BabyGruMap(commandCentre) {
     this.displayObjects = { Coot: [] }
     this.litLines = true
     this.isDifference = false
+    this.hasReflectionData = false
 }
 
 BabyGruMap.prototype.delete = async function (glRef) {


### PR DESCRIPTION
After this update, the menu item to connect updating maps is simplified. In essence, the corresponding column labels are asked when the MTZ file is uploaded and the reflection data is parsed accordingly. This way, when the user wants to connect updating maps,  there's no need to re-upload data.