### PR TITLE
Create app build compatible with CCP4 cloud using webpack

### DIFF
--- a/baby-gru/.babelrc
+++ b/baby-gru/.babelrc
@@ -1,0 +1,1 @@
+{"presets":["@babel/env", ["@babel/react", {"runtime": "automatic"}]]}

--- a/baby-gru/SimpleCrossOriginServer.py
+++ b/baby-gru/SimpleCrossOriginServer.py
@@ -1,0 +1,11 @@
+from http.server import HTTPServer, SimpleHTTPRequestHandler, test
+import sys
+
+class CORSRequestHandler (SimpleHTTPRequestHandler):
+    def end_headers (self):
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        SimpleHTTPRequestHandler.end_headers(self)
+
+if __name__ == '__main__':
+    test(CORSRequestHandler, HTTPServer, port=int(sys.argv[1]) if len(sys.argv) > 1 else 8000)

--- a/baby-gru/cloud/index.html
+++ b/baby-gru/cloud/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="./favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="./public/logo192.png" />
+  <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+  <link rel="manifest" href="./manifest.json" />
+  <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+
+  <script>
+    // See https://github.com/facebook/react/issues/20829#issuecomment-802088260
+    if (!crossOriginIsolated) SharedArrayBuffer = ArrayBuffer;
+  </script>
+
+  <!--Here some imports and actions to make some simple crystallographic logic available to the 
+main UI thread (as opposed to the CootWorker)-->
+  <script>
+    window.onload = () => {
+      createCCP4Module({
+        print(t) { console.log(["output", t]) },
+        printErr(t) { console.log(["output", t]); }
+      })
+        .then(function (CCP4Mod) {
+          window.CCP4Module = CCP4Mod;
+        })
+        .catch((e) => {
+          console.log("CCP4 problem :(");
+          console.log(e);
+        });
+    }
+  </script>
+  <script src="./baby-gru/wasm/web_example.js"></script>
+
+<!--Define the div ID where the app has to be rendered and uri the input PDB-->
+<script>
+    window.moorhenInput = {
+      rootId: "root",
+      urlPrefix: ".",
+      inputFiles: [
+        {type: 'pdb', args: ["./baby-gru/tutorials/moorhen-tutorial-structure-number-1.pdb", "molecule"]},
+        {type: 'mtz', args: [
+          "./baby-gru/tutorials/moorhen-tutorial-map-number-1.mtz", "map", 
+          {F: "FWT", PHI: "PHWT", Fobs: 'F', SigFobs: 'SIGF', FreeR: 'FREER'},
+          false, false
+        ]},
+        {type: 'mtz', args: [
+          "./baby-gru/tutorials/moorhen-tutorial-map-number-1.mtz", 'diff-map',
+          {F: "DELFWT", PHI: "PHDELWT"}, true, false
+        ]}
+      ]
+    }
+
+</script>
+
+  <title>Baby Gru</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+</body>
+
+</html>

--- a/baby-gru/cloud/index.html
+++ b/baby-gru/cloud/index.html
@@ -56,12 +56,11 @@ main UI thread (as opposed to the CootWorker)-->
         {type: 'pdb', args: ["./baby-gru/tutorials/moorhen-tutorial-structure-number-1.pdb", "molecule"]},
         {type: 'mtz', args: [
           "./baby-gru/tutorials/moorhen-tutorial-map-number-1.mtz", "map", 
-          {F: "FWT", PHI: "PHWT", Fobs: 'F', SigFobs: 'SIGF', FreeR: 'FREER'},
-          false, false
+          {F: "FWT", PHI: "PHWT", Fobs: 'F', SigFobs: 'SIGF', FreeR: 'FREER', isDifference: false, useWeight: false, calcStructFact: true}
         ]},
         {type: 'mtz', args: [
           "./baby-gru/tutorials/moorhen-tutorial-map-number-1.mtz", 'diff-map',
-          {F: "DELFWT", PHI: "PHDELWT"}, true, false
+          {F: "DELFWT", PHI: "PHDELWT", isDifference: true, useWeight: false, calcStructFact: false}
         ]}
       ]
     }

--- a/baby-gru/cloud/index.js
+++ b/baby-gru/cloud/index.js
@@ -33,9 +33,9 @@ class MoorhenWrapper {
     async loadInputFiles(inputFiles) {
       let promises = []
       for (const file of inputFiles) {
-        if (file.type == 'pdb') {
+        if (file.type === 'pdb') {
           promises.push(this.loadPdbData(...file.args))
-        } else if (file.type == 'mtz') {
+        } else if (file.type === 'mtz') {
           promises.push(this.loadMtzData(...file.args))
         }
       }
@@ -44,7 +44,7 @@ class MoorhenWrapper {
 
       setTimeout(() => {
         results.forEach((result, index) => {
-          if (result?.type == 'map') {
+          if (result?.type === 'map') {
             let contourOnSessionLoad = new CustomEvent("contourOnSessionLoad", {
               "detail": {
                   molNo: result.molNo,
@@ -77,11 +77,11 @@ class MoorhenWrapper {
       })
     }
 
-    async loadMtzData(inputFile, mapName, selectedColumns, isDiffMap, useWeights) {
+    async loadMtzData(inputFile, mapName, selectedColumns) {
       const newMap = new MoorhenMap(this.controls.commandCentre)
       return new Promise(async (resolve, reject) => {
           try {
-              await newMap.loadToCootFromMtzURL(inputFile, mapName, selectedColumns, isDiffMap, useWeights)
+              await newMap.loadToCootFromMtzURL(inputFile, mapName, selectedColumns)
               this.controls.changeMaps({ action: 'Add', item: newMap })
               this.controls.setActiveMap(newMap)
               return resolve(newMap)

--- a/baby-gru/cloud/index.js
+++ b/baby-gru/cloud/index.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import reportWebVitals from '../src/reportWebVitals';
+import { MoorhenContainer } from '../src/components/MoorhenContainer';
+import { PreferencesContextProvider } from "../src/utils/MoorhenPreferences";
+import { MoorhenMolecule } from "../src/utils/MoorhenMolecule"
+import { MoorhenMap } from "../src/utils/MoorhenMap"
+import '../src/index.css';
+import '../src/App.css';
+
+class MoorhenWrapper {
+    constructor(urlPrefix) {
+      this.urlPrefix = urlPrefix
+      this.controls = null
+    }
+  
+    forwardControls(controls) {
+      console.log('Fetched controls', {controls})
+      this.controls = controls
+    }
+
+    waitForInitialisation() {
+      const checkCootIsInitialised = resolve => {
+        if (this.controls) {
+          resolve()
+        } else {
+          setTimeout(_ => checkCootIsInitialised(resolve), 500);
+        }  
+      }
+      return new Promise(checkCootIsInitialised);
+    }
+
+    async loadInputFiles(inputFiles) {
+      let promises = []
+      for (const file of inputFiles) {
+        if (file.type == 'pdb') {
+          promises.push(this.loadPdbData(...file.args))
+        } else if (file.type == 'mtz') {
+          promises.push(this.loadMtzData(...file.args))
+        }
+      }
+
+      let results = await Promise.all(promises)
+
+      setTimeout(() => {
+        results.forEach((result, index) => {
+          if (result?.type == 'map') {
+            let contourOnSessionLoad = new CustomEvent("contourOnSessionLoad", {
+              "detail": {
+                  molNo: result.molNo,
+                  mapRadius: 13,
+                  cootContour: true,
+                  contourLevel: 0.8,
+                  litLines: false,
+              }
+          });               
+          document.dispatchEvent(contourOnSessionLoad);
+          }
+        })
+      }, 2500);
+
+    }
+
+    async loadPdbData(inputFile, molName) {
+      const newMolecule = new MoorhenMolecule(this.controls.commandCentre, this.urlPrefix)
+      return new Promise(async (resolve, reject) => {
+          try {
+              await newMolecule.loadToCootFromURL(inputFile, molName)
+              await newMolecule.fetchIfDirtyAndDraw('CBs', this.controls.glRef, true)
+              this.controls.changeMolecules({ action: "Add", item: newMolecule })
+              newMolecule.centreOn(this.controls.glRef)
+              return resolve(newMolecule)
+          } catch (err) {
+              console.log(`Cannot fetch molecule from ${inputFile}`)
+              return reject(err)
+          }   
+      })
+    }
+
+    async loadMtzData(inputFile, mapName, selectedColumns, isDiffMap, useWeights) {
+      const newMap = new MoorhenMap(this.controls.commandCentre)
+      return new Promise(async (resolve, reject) => {
+          try {
+              await newMap.loadToCootFromMtzURL(inputFile, mapName, selectedColumns, isDiffMap, useWeights)
+              this.controls.changeMaps({ action: 'Add', item: newMap })
+              this.controls.setActiveMap(newMap)
+              return resolve(newMap)
+          } catch (err) {
+              console.log(`Cannot fetch mtz from ${inputFile}`)
+              return reject(err)
+          }   
+      })
+  }
+  
+  renderMoorhen(rootId) {
+      const root = ReactDOM.createRoot(document.getElementById(rootId));
+      root.render(
+        <React.StrictMode>
+          <div className="App">
+            <PreferencesContextProvider>
+              <MoorhenContainer forwardControls={this.forwardControls.bind(this)} enableCloudExport={true}/>
+            </PreferencesContextProvider>
+          </div>
+        </React.StrictMode>
+      );
+    }
+  }
+  
+let moorhenWrapper = new MoorhenWrapper(window.moorhenInput.urlPrefix)
+moorhenWrapper.renderMoorhen(window.moorhenInput.rootId);
+moorhenWrapper.waitForInitialisation().then(_ => moorhenWrapper.loadInputFiles(window.moorhenInput.inputFiles))
+
+reportWebVitals();

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -11,8 +11,11 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",
+    "babel-cli": "^6.26.0",
+    "babel-preset-react-app": "^3.1.2",
     "bootstrap": "^5.1.3",
     "chart.js": "^3.7.1",
+    "copy-webpack-plugin": "^11.0.0",
     "d3": "^5.15.0",
     "gl-matrix": "^3.4.3",
     "html-react-parser": "^1.4.12",
@@ -42,6 +45,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "build-cloud": "webpack --mode production",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -62,5 +66,21 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.20.2",
+    "@babel/preset-react": "^7.18.6",
+    "@types/node": "^18.11.9",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^9.1.0",
+    "babel-preset-env": "^1.7.0",
+    "css-loader": "^6.7.2",
+    "html-webpack-plugin": "^5.5.0",
+    "style-loader": "^3.3.1",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.0",
+    "webpack-dev-server": "^4.11.1",
+    "webpack-node-externals": "^3.0.0",
+    "worker-loader": "^3.0.8"
   }
 }

--- a/baby-gru/webpack.config.js
+++ b/baby-gru/webpack.config.js
@@ -1,0 +1,75 @@
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const HTMLWebpackPlugin = require('html-webpack-plugin');
+
+const path = require('path');
+
+const paths = {
+  cloud: path.resolve(__dirname, 'cloud'),
+  src: path.resolve(__dirname, 'src'),
+  dist: path.resolve(__dirname, 'dist'),
+  public: path.resolve(__dirname, 'public'),
+  publicBabyGru: path.resolve(__dirname, 'public', 'baby-gru'),
+  pixmaps: path.resolve(__dirname, 'public', 'baby-gru', 'pixmaps'),
+}
+
+module.exports = {
+  plugins:[
+   
+    new HTMLWebpackPlugin({
+      filename: 'index.html',
+      template: path.join(paths.cloud, 'index.html'),
+      favicon: path.join(paths.public, 'favicon.ico')
+    }),
+    
+    new MiniCssExtractPlugin({
+      filename: '[name][contenthash].css',
+      chunkFilename: '[id].css',
+      ignoreOrder: false,
+    }),
+
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: paths.publicBabyGru,
+          to: paths.dist + '/baby-gru/',
+          toType: 'dir',
+        }
+      ],
+    }),
+  ],
+  entry: path.join(paths.cloud, 'index.js'),
+  target: 'web',
+  mode: 'production',
+  cache: false,
+  output: {
+    clean: true,
+    filename: '[name].js',
+    path: paths.dist,
+    publicPath: './'
+  },
+    module:{
+        rules:[
+            {
+                test: /\.js$/,
+                exclude: [/node_modules/, path.resolve(paths.src, 'index.js')],
+                loader: 'babel-loader',
+            },
+            {
+              test: /\.(?:ico|gif|png|jpg|jpeg|svg|xpm)$/,
+              loader: 'file-loader',
+              type: 'asset/resource',
+            },
+            {
+                test: /\.css$/,
+                sideEffects: true,
+                use: [ MiniCssExtractPlugin.loader, 'css-loader'],
+            }
+        ]
+    },
+    resolve: {
+        fallback: {
+          fs: false
+        }
+      }
+}


### PR DESCRIPTION
This adds a new directory with the index files for CCP4 cloud and a new option to `package.json`. The app can be built using `npm run build-cloud` and the resulting `dist` folder "should" be usable within cloud. There's a wrapper class `MoorhenWrapper` that controls the app, at the moment it only accepts input files.