### PR TITLE
Use gemmi to get molecule sequenec and other changes

### DIFF
--- a/baby-gru/src/components/MoorhenChainSelect.js
+++ b/baby-gru/src/components/MoorhenChainSelect.js
@@ -12,7 +12,7 @@ export const MoorhenChainSelect = forwardRef((props, selectRef) => {
     const getChainOptions = (selectedCoordMolNo) => {
         let selectedMolecule = props.molecules.find(molecule => molecule.molNo == selectedCoordMolNo)
         if (selectedMolecule) {
-            return selectedMolecule.cachedAtoms.sequences.map(sequence => props.allowedTypes.includes(sequence.type) ? <option value={sequence.chain} key={`${selectedMolecule.molNo}_${sequence.chain}`}>{sequence.chain}</option> : null)
+            return selectedMolecule.sequences.map(sequence => props.allowedTypes.includes(sequence.type) ? <option value={sequence.chain} key={`${selectedMolecule.molNo}_${sequence.chain}`}>{sequence.chain}</option> : null)
         }
         
     }

--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -296,7 +296,9 @@ export const MoorhenContainer = (props) => {
         </Backdrop>
 
         <Navbar ref={navBarRef} id='navbar-baby-gru' className={preferences.darkMode ? "navbar-dark" : "navbar-light"} style={{ height: '3rem', justifyContent: 'between', margin: '0.5rem', padding: '0.5rem' }}>
-            <Navbar.Brand href="#home">{appTitle}</Navbar.Brand>
+            <Navbar.Brand href="#home">
+                <img src={`${props.urlPrefix}/baby-gru/pixmaps/MoorhenLogo.png`} alt={appTitle} style={{height: '3rem'}}/>
+            </Navbar.Brand>
             <Navbar.Toggle aria-controls="basic-navbar-nav" />
             <Navbar.Collapse id="basic-navbar-nav">
                 <Nav className="justify-content-left">
@@ -430,5 +432,5 @@ export const MoorhenContainer = (props) => {
 
 MoorhenContainer.defaultProps = {
     urlPrefix: '.',
-    enableCloudMenu: true
+    enableCloudMenu: false
 }

--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -10,6 +10,7 @@ import { MoorhenFileMenu } from './MoorhenFileMenu';
 import { MoorhenCloudMenu } from './MoorhenCloudMenu';
 import { MoorhenPreferencesMenu } from './MoorhenPreferencesMenu';
 import { ArrowBackIosOutlined, ArrowForwardIosOutlined } from '@mui/icons-material';
+import { Backdrop } from '@mui/material';
 import { MoorhenHistoryMenu, historyReducer, initialHistoryState } from './MoorhenHistoryMenu';
 import { MoorhenViewMenu } from './MoorhenViewMenu';
 import { MoorhenLigandMenu } from './MoorhenLigandMenu';
@@ -288,6 +289,11 @@ export const MoorhenContainer = (props) => {
     }
 
     return <> <div className={`border ${theme}`} ref={headerRef}>
+
+        <Backdrop sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }} open={!cootInitialized}>
+            <Spinner animation="border" style={{ marginRight: '0.5rem' }}/>
+            <span>Starting moorhen...</span>
+        </Backdrop>
 
         <Navbar ref={navBarRef} id='navbar-baby-gru' className={preferences.darkMode ? "navbar-dark" : "navbar-light"} style={{ height: '3rem', justifyContent: 'between', margin: '0.5rem', padding: '0.5rem' }}>
             <Navbar.Brand href="#home">{appTitle}</Navbar.Brand>

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -148,7 +148,7 @@ export const MoorhenGetMonomerMenuItem = (props) => {
                     const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
                     newMolecule.molNo = result.data.result.result
                     newMolecule.name = tlcRef.current.value
-                    newMolecule.cachedAtoms.sequences = []
+                    newMolecule.sequences = []
                     return newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef).then(_ => {
                         props.changeMolecules({ action: "Add", item: newMolecule })
                         props.setPopoverIsShown(false)
@@ -478,7 +478,7 @@ export const MoorhenImportDictionaryMenuItem = (props) => {
                                 newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
                                 newMolecule.molNo = result.data.result.result
                                 newMolecule.name = instanceName
-                                newMolecule.cachedAtoms.sequences = []
+                                newMolecule.sequences = []
                                 newMolecule.addDict(fileContent)
                                 props.changeMolecules({ action: "Add", item: newMolecule })
                                 return newMolecule.fetchIfDirtyAndDraw("CBs", props.glRef)
@@ -1050,11 +1050,11 @@ export const MoorhenCopyFragmentUsingCidMenuItem = (props) => {
 
             const sequenceInputData = { returnType: "residue_codes", command: "get_single_letter_codes_for_chain", commandArgs: [response.data.result.result, 'A'] }
             const sequenceResponse = await props.commandCentre.current.cootCommand(sequenceInputData)
-            newMolecule.cachedAtoms.sequences = [{
+            newMolecule.sequences = [{
                 "sequence": sequenceResponse.data.result.result,
                 "name": newMolecule.name,
                 "chain": 'A',
-                "type": newMolecule.cachedAtoms.sequences.length > 0 ? newMolecule.cachedAtoms.sequences[0].type : 'ligand'
+                "type": newMolecule.sequences.length > 0 ? newMolecule.sequences[0].type : 'ligand'
             }]
         })
 

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -277,11 +277,11 @@ export const MoorhenMoleculeCard = (props) => {
                 <Accordion.Item eventKey="sequences" style={{ padding: '0', margin: '0' }} >
                     <Accordion.Header style={{ padding: '0', margin: '0' }}>Sequences</Accordion.Header>
                     <Accordion.Body>
-                        {props.molecule.cachedAtoms.sequences && props.molecule.cachedAtoms.sequences.length > 0 ?
+                        {props.molecule.sequences && props.molecule.sequences.length > 0 ?
                             <>
                                 <Row style={{ height: '100%' }}>
                                     <Col>
-                                        {props.molecule.cachedAtoms.sequences.map(
+                                        {props.molecule.sequences.map(
                                             sequence => {
                                                 if (!sequenceIsValid(sequence.sequence)) {
                                                     return (

--- a/baby-gru/src/components/MoorhenSearchBar.js
+++ b/baby-gru/src/components/MoorhenSearchBar.js
@@ -1,6 +1,7 @@
 import { Fragment, useState, useRef, useEffect } from "react";
-import { Row } from "react-bootstrap";
+import { Button, Row } from "react-bootstrap";
 import { Autocomplete, TextField } from "@mui/material";
+import { SearchOutlined, SearchOffOutlined, ArrowRightOutlined, ArrowLeftOutlined } from '@mui/icons-material';
 
 export const MoorhenSearchBar = (props) => {
 
@@ -8,6 +9,7 @@ export const MoorhenSearchBar = (props) => {
     const searchBarRef = useRef()
     const [selectedItemKey, setSelectedItemKey] = useState(null)
     const [openPopup, setOpenPopup] = useState(null)
+    const [isVisible, setIsVisible] = useState(false)
 
     const doClick = (element) => {
         console.log(`Search bar is clicking on ${element.id}`)
@@ -221,7 +223,19 @@ export const MoorhenSearchBar = (props) => {
 
 
     return <Fragment> 
-        <Row style={{padding: '0.5rem', width: '20rem'}}>
+        <Button className="nav-link" size="sm" variant="outlined" onClick={() => {setIsVisible(!isVisible)}}>
+            {isVisible ?
+            (<div>
+                 <SearchOffOutlined/>
+                 <ArrowLeftOutlined/>
+            </div>)
+             : 
+            (<div>
+                <SearchOutlined/>
+                <ArrowRightOutlined/>
+            </div>)}
+        </Button>   
+        <Row style={{padding: '0.5rem', width: '20rem', display: isVisible ? 'inline-block' : 'none'}}>
             <Autocomplete 
                     ref={selectRef}
                     disablePortal

--- a/baby-gru/src/components/MoorhenSearchBar.js
+++ b/baby-gru/src/components/MoorhenSearchBar.js
@@ -24,8 +24,6 @@ export const MoorhenSearchBar = (props) => {
     const getComputedStyle = (element, timeOut=800) => {
         return new Promise((resolve, reject) => {
             setTimeout(() => {
-                console.log('HELO')
-                console.log(window.getComputedStyle(element).display)
                 resolve(window.getComputedStyle(element))
             }, timeOut)    
         })

--- a/baby-gru/src/components/MoorhenValidation.js
+++ b/baby-gru/src/components/MoorhenValidation.js
@@ -65,7 +65,7 @@ export const MoorhenValidation = (props) => {
     const getSequenceData = () => {
         let selectedMolecule = props.molecules.find(molecule => molecule.molNo == selectedModel)
         if (selectedMolecule) {
-            let sequenceData = selectedMolecule.cachedAtoms.sequences.find(sequence => sequence.chain == chainSelectRef.current.value)
+            let sequenceData = selectedMolecule.sequences.find(sequence => sequence.chain == chainSelectRef.current.value)
             if (sequenceData) {
                 return sequenceData.sequence
             }    

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -84,6 +84,8 @@ MoorhenMolecule.prototype.parseSequences = function () {
             
         }
     }
+    console.log('Parsed the following sequences')
+    console.log(sequences)
     this.sequences = sequences
 }
 
@@ -148,8 +150,6 @@ MoorhenMolecule.prototype.loadToCootFromString = async function (coordData, name
     $this.gemmiStructure = readGemmiStructure(coordData, $this.name)
     window.CCP4Module.gemmi_setup_entities($this.gemmiStructure)
     $this.parseSequences()
-    console.log('HEL:OOOO')
-    console.log($this.sequences)
     $this.atomsDirty = false
 
     return this.commandCentre.current.cootCommand({

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -6,7 +6,7 @@ import { GetSplinesColoured } from '../WebGL/mgSecStr';
 import { atomsToSpheresInfo } from '../WebGL/mgWebGLAtomsToPrimitives';
 import { contactsToCylindersInfo, contactsToLinesInfo } from '../WebGL/mgWebGLAtomsToPrimitives';
 import { singletonsToLinesInfo } from '../WebGL/mgWebGLAtomsToPrimitives';
-import { readTextFile, readGemmiStructure, cidToSpec } from './MoorhenUtils'
+import { readTextFile, readGemmiStructure, cidToSpec, residueCodesThreeToOne, analyzeSequenceType } from './MoorhenUtils'
 import { quatToMat4 } from '../WebGL/quatToMat4.js';
 import * as vec3 from 'gl-matrix/vec3';
 
@@ -20,6 +20,7 @@ export function MoorhenMolecule(commandCentre, urlPrefix) {
     this.name = "unnamed"
     this.molNo = null
     this.gemmiStructure = null
+    this.sequences = []
     this.cootBondsOptions = {
         isDarkBackground: false,
         smoothness: 1,
@@ -47,9 +48,44 @@ MoorhenMolecule.prototype.updateGemmiStructure = async function () {
     let response = await this.getAtoms()
     this.gemmiStructure = readGemmiStructure(response.data.result.pdbData, this.name)
     window.CCP4Module.gemmi_setup_entities(this.gemmiStructure)
+    this.parseSequences()
     return Promise.resolve()
 }
 
+MoorhenMolecule.prototype.parseSequences = function () {
+    if (this.gemmiStructure === null) {
+        return
+    }
+    
+    let sequences = []
+    for (let modelIndex = 0; modelIndex < this.gemmiStructure.models.size(); modelIndex++) {
+        const model = this.gemmiStructure.models.get(modelIndex).clone()
+        window.CCP4Module.remove_ligands_and_waters_model(model)
+        for (let chainIndex = 0; chainIndex < model.chains.size(); chainIndex++) {
+            let currentSequence = []
+            const chain = model.chains.get(chainIndex)
+            const residues = chain.residues
+            for (let residueIndex = 0; residueIndex < residues.size(); residueIndex++) {
+                const residue = residues.get(residueIndex)
+                currentSequence.push({
+                    resNum: Number(residue.seqid.str()),
+                    resCode: residueCodesThreeToOne[residue.name]
+                })
+            }
+            if (currentSequence.length > 0){
+                sequences.push({
+                    name: `${this.name}_${chain.name}`,
+                    chain: chain.name,
+                    type: analyzeSequenceType(currentSequence.map(item => item.resCode).join('')),
+                    sequence: currentSequence
+                    
+                })
+            }
+            
+        }
+    }
+    this.sequences = sequences
+}
 
 MoorhenMolecule.prototype.delete = async function (glRef) {
     const $this = this
@@ -77,11 +113,11 @@ MoorhenMolecule.prototype.copyFragment = async function (chainId, res_no_start, 
 
     const sequenceInputData = { returnType: "residue_codes", command: "get_single_letter_codes_for_chain", commandArgs: [response.data.result, chainId] }
     const sequenceResponse = await $this.commandCentre.current.cootCommand(sequenceInputData)
-    newMolecule.cachedAtoms.sequences = [{
+    newMolecule.sequences = [{
         "sequence": sequenceResponse.data.result.result,
         "name": `${$this.name} fragment`,
         "chain": chainId,
-        "type": this.cachedAtoms.sequences.length > 0 ? this.cachedAtoms.sequences[0].type : 'ligand'
+        "type": this.sequences.length > 0 ? this.sequences[0].type : 'ligand'
     }]
 
     return newMolecule
@@ -111,6 +147,9 @@ MoorhenMolecule.prototype.loadToCootFromString = async function (coordData, name
     $this.cachedAtoms = $this.webMGAtomsFromFileString(coordData)
     $this.gemmiStructure = readGemmiStructure(coordData, $this.name)
     window.CCP4Module.gemmi_setup_entities($this.gemmiStructure)
+    $this.parseSequences()
+    console.log('HEL:OOOO')
+    console.log($this.sequences)
     $this.atomsDirty = false
 
     return this.commandCentre.current.cootCommand({
@@ -179,6 +218,7 @@ MoorhenMolecule.prototype.updateAtoms = function () {
             $this.cachedAtoms = $this.webMGAtomsFromFileString(result.data.result.pdbData)
             $this.gemmiStructure = readGemmiStructure(result.data.result.pdbData, $this.name)
             window.CCP4Module.gemmi_setup_entities($this.gemmiStructure)
+            $this.parseSequences()
             $this.atomsDirty = false
             resolve($this.cachedAtoms)
         })

--- a/baby-gru/src/utils/MoorhenUtils.js
+++ b/baby-gru/src/utils/MoorhenUtils.js
@@ -18,6 +18,28 @@ export function sequenceIsValid(sequence) {
     return true
 }
 
+export function analyzeSequenceType(thisSeq) {
+    // We need to try to determine saccharide chains as well.
+    let theType = "unknown";
+    let nposs_nuc = (thisSeq.match(/A/g)|| []).length + (thisSeq.match(/G/g)|| []).length + (thisSeq.match(/C/g)|| []).length + (thisSeq.match(/T/g)|| []).length + (thisSeq.match(/U/g)|| []).length + (thisSeq.match(/N/g)|| []).length;
+    if(nposs_nuc/thisSeq.length>0.9){
+        //Probably nucleic
+        if((thisSeq.match(/U/g)|| []).length > 0){
+            //Probably RNA
+            theType = "polyribonucleotide";
+        } else {
+            //Probably DNA
+            theType = "polydeoxyribonucleotide";
+        }
+    } else {
+        //Possibly/probably peptide
+        theType = "polypeptide(L)";
+    }
+
+    return theType;
+
+}
+
 export function convertRemToPx(rem) {
     return rem * parseFloat(getComputedStyle(document.documentElement).fontSize);
 }
@@ -51,6 +73,30 @@ export const residueCodesOneToThree = {
     '-': 'MISSING'
 }
 
+export const residueCodesThreeToOne = {
+        "ALA":'A',
+        "ARG":'R',
+        "ASN":'N',
+        "ASP":'D',
+        "CYS":'C',
+        "GLN":'Q',
+        "GLU":'E',
+        "GLY":'G',
+        "HIS":'H',
+        "ILE":'I',
+        "LEU":'L',
+        "LYS":'K',
+        "MET":'M',
+        "PHE":'F',
+        "PRO":'P',
+        "SER":'S',
+        "THR":'T',
+        "TRP":'W',
+        "TYR":'Y',
+        "VAL":'V',
+        "UNK":'X',
+}
+
 export const nucleotideCodesOneToThree = {
     "A": "A",
     "T": "T",
@@ -62,6 +108,30 @@ export const nucleotideCodesOneToThree = {
     "X": "UNKOWN",
     'UNK': 'UNKOWN',
     '-': 'MISSING'
+}
+
+export const nucleotideCodesThreeToOne = {
+    "A": "A",
+    "T": "T",
+    "G": "G",
+    "C": "C",
+    "U": "U",
+    "N": "N",
+    "I": "I",
+    "DT": "T",
+    "DG": "G",
+    "DC": "C",
+    "DA": "A",
+    "DU": "U",
+    "ADE": "A",
+    "THY": "T",
+    "GUA": "G",
+    "CYT": "C",
+    "URA": "U",
+    "PSU": "U",
+    "UNKOWN": "X",
+    'UNK': 'X',
+    'MISSING': '-'
 }
 
 export const postCootMessage = (cootWorker, kwargs) => {


### PR DESCRIPTION
After this update, `gemmi` is used to get the sequence of the chains in a given molecule. Components have been updated to read this data instead of the one parsed using `mgMinMol.js`.

 This update also includes:
- A spinner covers the whole screen when the app starts for the first time until coot is initialised to prevent the user from attempting to load data.
- Moorhen logo replaces the word "Moorhen" in the navbar (this will be available as soon as the logo makes it to pixmaps)
- Button to show/hide the search bar has been included.