### PR TITLE
Further integration of gemmi

### DIFF
--- a/baby-gru/src/components/MoorhenDifferenceMapPeaks.js
+++ b/baby-gru/src/components/MoorhenDifferenceMapPeaks.js
@@ -42,7 +42,7 @@ export const MoorhenDifferenceMapPeaks = (props) => {
     const [plotData, setPlotData] = useState(null)
     const [selectedModel, setSelectedModel] = useState(null)
     const [selectedMap, setSelectedMap] = useState(null)
-    const [cachedAtoms, setCachedAtoms] = useState(null)
+    const [cachedStructure, setCachedStructure] = useState(null)
     const [selectedRmsd, setSelectedRmsd] = useState(4.5)
     const [mapRmsd, setMapRmsd] = useState(null)
     
@@ -136,7 +136,7 @@ export const MoorhenDifferenceMapPeaks = (props) => {
         if (selectedModel !== null) {
             let selectedMoleculeIndex = props.molecules.findIndex(molecule => molecule.molNo == selectedModel);
             if (selectedMoleculeIndex != -1 && props.molecules[selectedMoleculeIndex]){
-                setCachedAtoms(props.molecules[selectedMoleculeIndex].cachedAtoms)
+                setCachedStructure(props.molecules[selectedMoleculeIndex].gemmiStructure)
             }
         }
     })
@@ -173,7 +173,7 @@ export const MoorhenDifferenceMapPeaks = (props) => {
             
         fetchData()
 
-    }, [selectedMap, selectedModel, cachedAtoms, selectedRmsd])
+    }, [selectedMap, selectedModel, cachedStructure, selectedRmsd])
 
     useEffect(() => {
         if (chartRef.current) {

--- a/baby-gru/src/components/MoorhenLigandList.js
+++ b/baby-gru/src/components/MoorhenLigandList.js
@@ -3,7 +3,7 @@ import { Card, Row, Col, Button } from "react-bootstrap";
 
 export const MoorhenLigandList = (props) => {
     const [ligandList, setLigandList] = useState([])
-    const [cachedAtoms, setCachedAtoms] = useState(null)
+    const [cachedStructure, setCachedStructure] = useState(null)
 
     useEffect(() => {
         async function updateMoleculeAtoms() {
@@ -30,10 +30,10 @@ export const MoorhenLigandList = (props) => {
         }
         setLigandList(ligandList)
 
-    }, [cachedAtoms])
+    }, [cachedStructure])
 
     useEffect(() => {
-        setCachedAtoms(props.molecule.cachedAtoms)
+        setCachedStructure(props.molecule.gemmiStructure)
     })
 
     return <>

--- a/baby-gru/src/components/MoorhenLigandList.js
+++ b/baby-gru/src/components/MoorhenLigandList.js
@@ -49,7 +49,7 @@ export const MoorhenLigandList = (props) => {
                                                         {`${ligand.chainName}/${ligand.res.seqid.str()}(${ligand.res.name})`}
                                                     </Col>
                                                     <Col className='col-3' style={{justifyContent: 'right', display:'flex'}}>
-                                                        <Button onClick={() => {props.molecule.centreOn(props.glRef, {chain: ligand.chainName, molName: props.molecule.name, molNo: props.molecule.molNo, modelIndex: 0, seqNum: ligand.res.seqid.str()})}}>
+                                                        <Button onClick={() => {props.molecule.centreOn(props.glRef, `/*/${ligand.chainName}/${ligand.res.seqid.str()}-${ligand.res.seqid.str()}/*`)}}>
                                                             View
                                                         </Button>
                                                     </Col>

--- a/baby-gru/src/components/MoorhenLigandMenu.js
+++ b/baby-gru/src/components/MoorhenLigandMenu.js
@@ -1,6 +1,6 @@
 import { NavDropdown } from "react-bootstrap";
 import { useState } from "react";
-import { MoorhenAddWatersMenuItem, MoorhenCentreOnLigandMenuItem, MoorhenGetMonomerMenuItem, MoorhenImportDictionaryMenuItem, MoorhenMergeMoleculesMenuItem } from "./MoorhenMenuItem";
+import { MoorhenAddWatersMenuItem, MoorhenCentreOnLigandMenuItem, MoorhenGetMonomerMenuItem, MoorhenImportDictionaryMenuItem } from "./MoorhenMenuItem";
 
 export const MoorhenLigandMenu = (props) => {
     const [popoverIsShown, setPopoverIsShown] = useState(false)

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -940,13 +940,8 @@ export const MoorhenGoToMenuItem = (props) => {
         }
 
         const resNum = resInfo.split("(")[0]
-        const selectedResidue = {
-            molName: molName,
-            modelIndex: 0,
-            seqNum: resNum,
-            chain: chainId
-        }
-        molecule.centreOn(props.glRef, selectedResidue)
+
+        molecule.centreOn(props.glRef, `/*/${chainId}/${resNum}-${resNum}/*`)
     }
 
     return <MoorhenMenuItem

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -109,7 +109,7 @@ export const MoorhenMoleculeCard = (props) => {
             return
         }
 
-        props.molecule.centreOn(props.glRef, clickedResidue)
+        props.molecule.centreOn(props.glRef, `/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
 
     }, [clickedResidue]);
 

--- a/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
+++ b/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
@@ -10,7 +10,7 @@ export const MoorhenPepflipsDifferenceMap = (props) => {
     const [pepflips, setPepflips] = useState(null)
     const [selectedModel, setSelectedModel] = useState(null)
     const [selectedMap, setSelectedMap] = useState(null)
-    const [cachedAtoms, setCachedAtoms] = useState(null)
+    const [cachedStructure, setCachedStructure] = useState(null)
     const [selectedRmsd, setSelectedRmsd] = useState(4.5)
     const [cardList, setCardList] = useState([])
     
@@ -101,7 +101,7 @@ export const MoorhenPepflipsDifferenceMap = (props) => {
         if (selectedModel !== null) {
             let selectedMoleculeIndex = props.molecules.findIndex(molecule => molecule.molNo == selectedModel);
             if (selectedMoleculeIndex != -1 && props.molecules[selectedMoleculeIndex]){
-                setCachedAtoms(props.molecules[selectedMoleculeIndex].cachedAtoms)
+                setCachedStructure(props.molecules[selectedMoleculeIndex].gemmiStructure)
             }
         }
     })
@@ -127,7 +127,7 @@ export const MoorhenPepflipsDifferenceMap = (props) => {
     
         fetchData(inputData)   
 
-    }, [selectedMap, selectedModel, cachedAtoms, selectedRmsd])
+    }, [selectedMap, selectedModel, cachedStructure, selectedRmsd])
 
     useEffect(() => {
 

--- a/baby-gru/src/components/MoorhenRamachandran.js
+++ b/baby-gru/src/components/MoorhenRamachandran.js
@@ -116,7 +116,7 @@ export const MoorhenRamachandran = (props) => {
             return
         }
 
-        props.molecules[selectedMoleculeIndex].centreOn(props.glRef, clickedResidue)
+        props.molecules[selectedMoleculeIndex].centreOn(props.glRef, `/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
 
     }, [clickedResidue])
 

--- a/baby-gru/src/components/MoorhenRamachandran.js
+++ b/baby-gru/src/components/MoorhenRamachandran.js
@@ -15,7 +15,7 @@ export const MoorhenRamachandran = (props) => {
     const [ramaPlotData, setRamaPlotData] = useState(null)
     const [selectedModel, setSelectedModel] = useState(null)
     const [selectedChain, setSelectedChain] = useState(null)
-    const [cachedAtoms, setCachedAtoms] = useState(null)
+    const [cachedStructure, setCachedStructure] = useState(null)
 
     const getMolName = () => {
         if (selectedModel === null || props.molecules.length === 0) {
@@ -80,13 +80,13 @@ export const MoorhenRamachandran = (props) => {
         if (selectedModel !== null) {
             let selectedMoleculeIndex = props.molecules.findIndex(molecule => molecule.molNo == selectedModel);
             if (selectedMoleculeIndex != -1 && props.molecules[selectedMoleculeIndex]){
-                setCachedAtoms(props.molecules[selectedMoleculeIndex].cachedAtoms)
+                setCachedStructure(props.molecules[selectedMoleculeIndex].gemmiStructure)
             }
         }
     })
 
     useEffect(() => {
-        console.log('cachedAtoms changed')
+        console.log('cachedStructure changed')
         if (ramaPlotData === null || selectedModel === null || chainSelectRef.current.value === null || props.molecules.length === 0) {
             return;
         }
@@ -103,7 +103,7 @@ export const MoorhenRamachandran = (props) => {
         
         fetchRamaData()
 
-    }, [cachedAtoms])
+    }, [cachedStructure])
 
     useEffect(() => {
         if (!clickedResidue) {

--- a/baby-gru/src/components/MoorhenValidation.js
+++ b/baby-gru/src/components/MoorhenValidation.js
@@ -60,7 +60,7 @@ export const MoorhenValidation = (props) => {
     const [selectedModel, setSelectedModel] = useState(null)
     const [selectedMap, setSelectedMap] = useState(null)
     const [selectedChain, setSelectedChain] = useState(null)
-    const [cachedAtoms, setCachedAtoms] = useState(null)
+    const [cachedStructure, setCachedStructure] = useState(null)
 
     const getSequenceData = () => {
         let selectedMolecule = props.molecules.find(molecule => molecule.molNo == selectedModel)
@@ -191,7 +191,7 @@ export const MoorhenValidation = (props) => {
         if (selectedModel !== null) {
             let selectedMoleculeIndex = props.molecules.findIndex(molecule => molecule.molNo == selectedModel);
             if (selectedMoleculeIndex != -1 && props.molecules[selectedMoleculeIndex]){
-                setCachedAtoms(props.molecules[selectedMoleculeIndex].cachedAtoms)
+                setCachedStructure(props.molecules[selectedMoleculeIndex].gemmiStructure)
             }
         }
     })
@@ -220,7 +220,7 @@ export const MoorhenValidation = (props) => {
         let availableMetrics = getAvailableMetrics()
         fetchData(availableMetrics)   
 
-    }, [selectedChain, selectedMap, selectedModel, cachedAtoms])
+    }, [selectedChain, selectedMap, selectedModel, cachedStructure])
 
     useEffect(() => {
         if (chartRef.current) {

--- a/baby-gru/src/components/MoorhenValidation.js
+++ b/baby-gru/src/components/MoorhenValidation.js
@@ -139,7 +139,7 @@ export const MoorhenValidation = (props) => {
         if(selectedMolecule) {
             const clickedResidue = getResidueInfo(selectedMolecule, residueIndex)
             if (clickedResidue) {
-                selectedMolecule.centreOn(props.glRef, clickedResidue)
+                selectedMolecule.centreOn(props.glRef, `/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
             }
         }
     }

--- a/baby-gru/src/components/MoorhenWebMG.js
+++ b/baby-gru/src/components/MoorhenWebMG.js
@@ -54,13 +54,8 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
             }
                         
             const resNum = resInfo.split("(")[0]
-            const selectedResidue = {
-                molName: props.hoveredAtom.molecule.name,
-                modelIndex: 0,
-                seqNum: resNum,
-                chain: chainId
-            }
-            props.hoveredAtom.molecule.centreOn(glRef, selectedResidue)
+
+            props.hoveredAtom.molecule.centreOn(glRef, `/*/${chainId}/${resNum}-${resNum}/*`)
         }
     }, [props.hoveredAtom])
 

--- a/baby-gru/src/utils/MoorhenUtils.js
+++ b/baby-gru/src/utils/MoorhenUtils.js
@@ -308,6 +308,26 @@ export const MoorhenMtzWrapper = class {
     }
 }
 
+export const centreOnGemmiAtoms = (atoms) => {
+    const atomCount = atoms.length
+    if (atomCount === 0) {
+        return [0, 0, 0]
+    }
+
+    let xtot = 0.0
+    let ytot = 0.0
+    let ztot = 0.0
+    
+    for (const atom of atoms) {
+        xtot += atom.pos.x
+        ytot += atom.pos.y
+        ztot += atom.pos.z
+    }
+    
+    return [-xtot/atomCount, -ytot/atomCount, -ztot/atomCount]
+    
+}
+
 export const cidToSpec = (cid) => {
     //molNo, chain_id, res_no, ins_code, alt_conf
     const cidTokens = cid.split('/')


### PR DESCRIPTION
After this update:

- Hooks used to re-render widgets after the molecule has changed now use gemmi structure as the dependency instead of `MoorhenMolecule.cachedAtoms`
- Gemmi is used to centre on a selection of atoms defined using a cid, instead of `MoorhenMolecule.cachedAtoms`