### PR TITLE
Moved rotate/translate molecule

### DIFF
--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -1,7 +1,5 @@
 import { useRef, useState, useEffect, createRef, useReducer, useCallback, useContext } from 'react';
-import { Navbar, Container, Nav, Accordion, Button, Col, Row, Spinner, Form } from 'react-bootstrap';
-import Toast from 'react-bootstrap/Toast';
-import ToastContainer from 'react-bootstrap/ToastContainer';
+import { Navbar, Container, Nav, Accordion, Button, Col, Row, Spinner, Form, Toast, ToastContainer } from 'react-bootstrap';
 import { MoorhenDisplayObjects } from './MoorhenDisplayObjects';
 import { MoorhenWebMG } from './MoorhenWebMG';
 import { MoorhenCommandCentre, convertRemToPx, convertViewtoPx } from '../utils/MoorhenUtils';

--- a/baby-gru/src/components/MoorhenHelpMenu.js
+++ b/baby-gru/src/components/MoorhenHelpMenu.js
@@ -1,4 +1,4 @@
-import { Form, NavDropdown } from "react-bootstrap";
+import { NavDropdown } from "react-bootstrap";
 import { useState } from "react";
 import { MoorhenSearchBar } from './MoorhenSearchBar';
 import { MenuItem } from "@mui/material";

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -269,7 +269,6 @@ export const MoorhenRotateTranslateMoleculeMenuItem = (props) => {
         document.body.click()
     }
 
-
     const startTransform = async () => {
         const newMolecule = await props.molecule.copyMolecule(props.glRef)
         props.changeMolecules({ action: "Add", item: newMolecule })

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -1,6 +1,7 @@
 import { MenuItem } from "@mui/material";
+import { CheckOutlined, CloseOutlined } from "@mui/icons-material";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { OverlayTrigger, Popover, PopoverBody, PopoverHeader, Form, InputGroup, Button, FormSelect, Row, Col, SplitButton, Dropdown } from "react-bootstrap";
+import { OverlayTrigger, Popover, PopoverBody, PopoverHeader, Form, InputGroup, Button, FormSelect, Row, Col, SplitButton, Dropdown, Toast, ToastContainer } from "react-bootstrap";
 import { SketchPicker } from "react-color";
 import { MoorhenMtzWrapper, readTextFile } from "../utils/MoorhenUtils";
 import { MoorhenMap } from "../utils/MoorhenMap";
@@ -24,12 +25,8 @@ export const MoorhenMenuItem = (props) => {
             placement={props.popoverPlacement}
             trigger="click"
 
-            onEntered={() => {
-                props.setPopoverIsShown(true)
-            }}
-
-            onExit={() => {
-                props.setPopoverIsShown(false)
+            onEntering={() =>{
+                props.onEntering()
             }}
 
             onEnter={() => {
@@ -41,12 +38,29 @@ export const MoorhenMenuItem = (props) => {
                 })
             }}
 
+            onEntered={() => {
+                props.setPopoverIsShown(true)
+            }}
+
+            onExit={() => {
+                props.setPopoverIsShown(false)
+            }}
+
+            onExiting={() => {
+                props.onExiting()
+            }}
+
             overlay={
                 <Popover style={{ maxWidth: "40rem" }}>
                     <PopoverHeader as="h3">{props.menuItemTitle}</PopoverHeader>
                     <PopoverBody>
                         {props.popoverContent}
-                        <Button variant={props.buttonVariant} onClick={() => { resolveOrRejectRef.current.resolve() }}>{props.buttonText}</Button>
+                        {props.showOkButton && 
+                            <Button variant={props.buttonVariant} onClick={() => { resolveOrRejectRef.current.resolve() }}>
+                                {props.buttonText}
+                            </Button>
+                        }
+                        
                     </PopoverBody>
                 </Popover>}
         >
@@ -59,10 +73,14 @@ export const MoorhenMenuItem = (props) => {
 
 MoorhenMenuItem.defaultProps = {
     id: '',
+    showOkButton: true,
     buttonText: "OK",
     buttonVariant: "primary",
     textClassName: "",
-    popoverPlacement: "right"
+    popoverPlacement: "right",
+    onEntering: () => { },
+    onExiting: () => { },
+    onCompleted: () => { }
 }
 
 export const MoorhenLoadTutorialDataMenuItem = (props) => {
@@ -227,6 +245,58 @@ export const MoorhenRenameDisplayObjectMenuItem = (props) => {
     />
 }
 
+export const MoorhenRotateTranslateMoleculeMenuItem = (props) => {
+    const ghostMolecule = useRef(null)
+
+    const onExiting = () => {
+        props.glRef.current.setActiveMolecule(null)
+        props.changeMolecules({ action: 'Remove', item: ghostMolecule.current })
+        ghostMolecule.current.delete(props.glRef)
+    }
+
+    const acceptTransform = async () => {
+        props.setPopoverIsShown(false)
+        props.glRef.current.setActiveMolecule(null)
+        const transformedAtoms = ghostMolecule.current.transformedCachedAtomsAsMovedAtoms(props.glRef)
+        await props.molecule.updateWithMovedAtoms(transformedAtoms, props.glRef)
+        props.changeMolecules({ action: 'Remove', item: ghostMolecule.current })
+        ghostMolecule.current.delete(props.glRef)
+        document.body.click()
+    }
+
+    const rejectTransform = () => {
+        onExiting()
+        document.body.click()
+    }
+
+
+    const startTransform = async () => {
+        const newMolecule = await props.molecule.copyMolecule(props.glRef)
+        props.changeMolecules({ action: "Add", item: newMolecule })
+        props.glRef.current.setActiveMolecule(newMolecule)
+        ghostMolecule.current = newMolecule
+    }
+
+    const panelContent =
+        <>
+            <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenRotateTranslateMolecule">
+                <Form.Label>Accept rotate/translate ?</Form.Label>
+                <Button onClick={acceptTransform}><CheckOutlined /></Button>
+                <Button className="mx-2" onClick={rejectTransform}><CloseOutlined /></Button>
+            </Form.Group>        
+        </>
+
+    return <MoorhenMenuItem
+    showOkButton={false}
+    popoverPlacement='left'
+    popoverContent={panelContent}
+    menuItemText={"Rotate/Translate molecule"}
+    onEntering={startTransform}
+    onExiting={onExiting}
+    setPopoverIsShown={props.setPopoverIsShown}
+/>
+}
+
 export const MoorhenMoleculeBondSettingsMenuItem = (props) => {
     const smoothnesSelectRef = useRef(null)
 
@@ -252,7 +322,6 @@ export const MoorhenMoleculeBondSettingsMenuItem = (props) => {
         popoverPlacement='left'
         popoverContent={panelContent}
         menuItemText={"Bond settings"}
-        onCompleted={() => { }}
         setPopoverIsShown={props.setPopoverIsShown}
     />
 }
@@ -1158,7 +1227,6 @@ export const MoorhenCentreOnLigandMenuItem = (props) => {
                 </Tree>
             }
             menuItemText="Centre on ligand..."
-            onCompleted={() => { }}
             setPopoverIsShown={props.setPopoverIsShown}
         />
     </>

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -250,26 +250,6 @@ export const MoorhenMoleculeCard = (props) => {
                                 </div>
                             </Col>
                         </Row>
-                        <hr></hr>
-                        <Row style={{ height: '100%' }}>
-                            <Col>
-                                <Form.Check checked={props.molecule === props.activeMolecule}
-                                    style={{ margin: '0' }}
-                                    inline
-                                    label={`Rotate/Translate`}
-                                    type="checkbox"
-                                    variant="outline"
-                                    disabled={!isVisible}
-                                    onChange={(e) => {
-                                        if (e.target.checked) {
-                                            props.setActiveMolecule(props.molecule)
-                                        } else {
-                                            props.setActiveMolecule(null)
-                                        }
-                                    }}
-                                />
-                            </Col>
-                        </Row>
                     </Accordion.Body>
                 </Accordion.Item>
 

--- a/baby-gru/src/components/MoorhenMoleculeCardButtonBar.js
+++ b/baby-gru/src/components/MoorhenMoleculeCardButtonBar.js
@@ -1,19 +1,14 @@
-import React, { useEffect, useState, useMemo, Fragment, forwardRef, useRef, useCallback } from "react";
+import React, { useState, useMemo, Fragment, useRef } from "react";
 import { Button, DropdownButton } from "react-bootstrap";
 import { convertViewtoPx } from '../utils/MoorhenUtils';
 import { MenuItem } from "@mui/material";
 import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined, DownloadOutlined, Settings } from '@mui/icons-material';
-import { MoorhenDeleteDisplayObjectMenuItem, MoorhenRenameDisplayObjectMenuItem, MoorhenMoleculeBondSettingsMenuItem, MoorhenMergeMoleculesMenuItem } from "./MoorhenMenuItem";
+import { MoorhenDeleteDisplayObjectMenuItem, MoorhenRenameDisplayObjectMenuItem, MoorhenMoleculeBondSettingsMenuItem, MoorhenMergeMoleculesMenuItem, MoorhenRotateTranslateMoleculeMenuItem } from "./MoorhenMenuItem";
 
 export const MoorhenMoleculeCardButtonBar = (props) => {
     const dropdownCardButtonRef = useRef()
     const [popoverIsShown, setPopoverIsShown] = useState(false)
-    const [dropdownMenuItemShown, setDropdownMenuItemShown] = useState(0)
     const [currentName, setCurrentName] = useState(props.molecule.name);
-
-    useEffect(() => {
-        setDropdownMenuItemShown(0)
-    }, [props.windowHeight, props.sideBarWidth]);
 
     useMemo(() => {
         if (currentName == "") {
@@ -95,72 +90,32 @@ export const MoorhenMoleculeCardButtonBar = (props) => {
             compressed: () => { return (<MoorhenMoleculeBondSettingsMenuItem key={10} setPopoverIsShown={setPopoverIsShown} molecule={props.molecule} {...props.bondSettingsProps}/>) },
             expanded: null
         },
+        11: {
+            label: 'Rotate/Translate molecule',
+            compressed: () => { return (<MoorhenRotateTranslateMoleculeMenuItem key={11} setPopoverIsShown={setPopoverIsShown} molecule={props.molecule} changeMolecules={props.changeMolecules} glRef={props.glRef}/>) },
+            expanded: null
+        },
     }
-
+ 
     const maximumAllowedWidth = props.sideBarWidth * 0.35
-    const maximumAllowedHeight = convertViewtoPx(40, props.windowHeight) * 0.5
     let currentlyUsedWidth = 0
-    let currentlyUsedHeight = 0
     let expandedButtons = []
-    let compressedButtons = [[]]
-    let currentCompressedButtonItemIndex = 0
-    
-    const handleTransition = useCallback(() => {
-        setDropdownMenuItemShown((prev) => {
-            let newValue = prev + 1
-            if (newValue !== compressedButtons.length) {
-                return newValue
-            } else {
-                return 0
-            }
-        })
-    }, [compressedButtons.length])
-
-    const getTransitionButton = (index) => {
-        return  <MenuItem style={{width: '20rem', justifyContent:'between', display:'flex'}} key={`${index}_next_item`} variant="success" onClick={handleTransition}>
-                    <ExpandMoreOutlined/> More...
-                </MenuItem>
-    }
-
-    const SlideItem = forwardRef((props, ref) => {
-        return (
-          <div ref={ref} style={{display: props.index == dropdownMenuItemShown ? "" : "none"}}>
-            {compressedButtons[props.index]}
-          </div>
-        );
-      })
-      
+    let compressedButtons = []
 
     Object.keys(actionButtons).forEach(key => {
         if (actionButtons[key].expanded === null) {
-            currentlyUsedHeight += 35
-            if (currentlyUsedHeight < maximumAllowedHeight) {
-                compressedButtons[currentCompressedButtonItemIndex].push(actionButtons[key].compressed())
-            } else {
-                compressedButtons[currentCompressedButtonItemIndex].push(getTransitionButton(currentCompressedButtonItemIndex))
-                currentCompressedButtonItemIndex ++
-                compressedButtons.push([actionButtons[key].compressed()])
-                currentlyUsedHeight = 35
-            }
+            compressedButtons.push(actionButtons[key].compressed())
         } else {
             currentlyUsedWidth += 60
             if (currentlyUsedWidth < maximumAllowedWidth) {
                 expandedButtons.push(actionButtons[key].expanded())
             } else {
-                currentlyUsedHeight += 35
-                if (currentlyUsedHeight < maximumAllowedHeight) {
-                    compressedButtons[currentCompressedButtonItemIndex].push(actionButtons[key].compressed())
-                } else {
-                    compressedButtons[currentCompressedButtonItemIndex].push(getTransitionButton(currentCompressedButtonItemIndex))
-                    currentCompressedButtonItemIndex ++
-                    compressedButtons.push([actionButtons[key].compressed()])
-                    currentlyUsedHeight = 35
-                }
+                compressedButtons.push(actionButtons[key].compressed())
             }
         }
     })
 
-    compressedButtons[currentCompressedButtonItemIndex].push(
+    compressedButtons.push(
         <MoorhenDeleteDisplayObjectMenuItem 
         key="deleteDisplayObjectMenuItem"
         setPopoverIsShown={setPopoverIsShown} 
@@ -169,10 +124,6 @@ export const MoorhenMoleculeCardButtonBar = (props) => {
         itemList={props.molecules} 
         item={props.molecule} />
     )
-
-    if (compressedButtons.length > 1) {
-        compressedButtons[currentCompressedButtonItemIndex].push(getTransitionButton(currentCompressedButtonItemIndex))
-    }
 
     return <Fragment>
         {expandedButtons}
@@ -186,7 +137,9 @@ export const MoorhenMoleculeCardButtonBar = (props) => {
             show={props.currentDropdownMolNo === props.molecule.molNo}
             onToggle={() => { props.molecule.molNo !== props.currentDropdownMolNo ? props.setCurrentDropdownMolNo(props.molecule.molNo) : props.setCurrentDropdownMolNo(-1) }}
             >
-                {compressedButtons[dropdownMenuItemShown]}
+                <div style={{height: convertViewtoPx(40, props.windowHeight) * 0.5, overflowY: 'scroll'}}>
+                    {compressedButtons}
+                </div>
             </DropdownButton>
         <Button key="expandButton"
             size="sm" variant="outlined"

--- a/baby-gru/src/components/MoorhenMoleculeCardButtonBar.js
+++ b/baby-gru/src/components/MoorhenMoleculeCardButtonBar.js
@@ -96,7 +96,7 @@ export const MoorhenMoleculeCardButtonBar = (props) => {
             expanded: null
         },
     }
- 
+
     const maximumAllowedWidth = props.sideBarWidth * 0.35
     let currentlyUsedWidth = 0
     let expandedButtons = []

--- a/baby-gru/src/components/MoorhenSearchBar.js
+++ b/baby-gru/src/components/MoorhenSearchBar.js
@@ -1,16 +1,13 @@
 import { Fragment, useState, useRef, useEffect } from "react";
-import { Button, Row } from "react-bootstrap";
-import { Autocomplete, Slide, TextField } from "@mui/material";
-import { SearchOutlined, SearchOffOutlined, ArrowRightOutlined, ArrowLeftOutlined } from '@mui/icons-material';
+import { Row } from "react-bootstrap";
+import { Autocomplete, TextField } from "@mui/material";
 
 export const MoorhenSearchBar = (props) => {
 
     const selectRef = useRef()
     const searchBarRef = useRef()
-    const searchBarContainerRef = useRef()
     const [selectedItemKey, setSelectedItemKey] = useState(null)
     const [openPopup, setOpenPopup] = useState(null)
-    const [isVisible, setIsVisible] = useState(false)
 
     const doClick = (element) => {
         console.log(`Search bar is clicking on ${element.id}`)

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -98,6 +98,24 @@ MoorhenMolecule.prototype.delete = async function (glRef) {
     return response
 }
 
+MoorhenMolecule.prototype.copyMolecule = async function (glRef) {
+
+    let moleculeAtoms = await this.getAtoms()
+    let newMolecule = new MoorhenMolecule(this.commandCentre, this.urlPrefix)
+    newMolecule.name = `${this.name}-placeholder`
+
+    let response = await this.commandCentre.current.cootCommand({
+        returnType: "status",
+        command: 'shim_read_pdb',
+        commandArgs: [moleculeAtoms.data.result.pdbData, newMolecule.name]
+    }, true)    
+    
+    newMolecule.molNo = response.data.result.result
+
+    await newMolecule.fetchIfDirtyAndDraw('CBs', glRef)
+    return newMolecule
+}
+
 MoorhenMolecule.prototype.copyFragment = async function (chainId, res_no_start, res_no_end, glRef, doRecentre) {
     if (typeof doRecentre === 'undefined') {
         doRecentre = true


### PR DESCRIPTION
After this update, rotate/translate molecule gets moved to the dropdown menu in the molecule card. This dropdown menu is now scrollable (it was getting too big). Also, a ghost molecule is shown and the user can accept/reject the transformation.