### PR TITLE
Add api/coot_molecule_backup.cc to and api/coot_molecule_bonds_instanced.cc the build

### DIFF
--- a/coot/CMakeLists.txt
+++ b/coot/CMakeLists.txt
@@ -108,6 +108,7 @@ ${coot_src}/api/interfaces.cc
 ${coot_src}/api/colour-functions.cc
 ${coot_src}/api/coot-colour.cc
 ${coot_src}/api/coot_molecule.cc
+${coot_src}/api/coot_molecule_backup.cc
 ${coot_src}/api/coot_molecule_bonds.cc
 ${coot_src}/api/coot_molecule_maps.cc
 ${coot_src}/api/coot_molecule_moltris.cc

--- a/coot/CMakeLists.txt
+++ b/coot/CMakeLists.txt
@@ -110,6 +110,7 @@ ${coot_src}/api/coot-colour.cc
 ${coot_src}/api/coot_molecule.cc
 ${coot_src}/api/coot_molecule_backup.cc
 ${coot_src}/api/coot_molecule_bonds.cc
+${coot_src}/api/coot_molecule_bonds_instanced.cc
 ${coot_src}/api/coot_molecule_maps.cc
 ${coot_src}/api/coot_molecule_moltris.cc
 ${coot_src}/api/phi-psi-prob.cc


### PR DESCRIPTION
So now, there can be gui control over the creation of backups.

Also, there is now infrastructure for the instanced bonds mesh. Not perfect I'd guess, orientation matrices may need to be adjusted.
