### PR TITLE
Delete selected atoms after we are done with them

### DIFF
--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -1219,7 +1219,7 @@ export const MoorhenCentreOnLigandMenuItem = (props) => {
                                     reducedValue.sumXyz.map(coord => -coord / reducedValue.count)
                                     , true)
                             }
-
+                            selAtoms.forEach(atom => atom.delete())
                         }
                     }}
                 >

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -292,6 +292,7 @@ MoorhenMolecule.prototype.centreOn = function (glRef, selectionCid) {
         }
 
         let selectionCentre = centreOnGemmiAtoms(selectionAtoms)
+        selectionAtoms.forEach(atom => atom.delete())
 
         return new Promise((resolve, reject) => {
             glRef.current.setOrigin(selectionCentre);
@@ -757,6 +758,7 @@ MoorhenMolecule.prototype.drawHover = async function (glRef, selectionString) {
         ]
         $this.clearBuffersOfStyle(style, glRef)
         this.addBuffersOfStyle(glRef, objects, style)
+        selectedGemmiAtoms.forEach(atom => atom.delete())
     }
     return
 


### PR DESCRIPTION
This deletes gemmi atoms generated by `MoorhenMolecule.gemmiAtomsForCid` after we are done using them