### PR TITLE
Fix unique key props warning

### DIFF
--- a/baby-gru/src/components/MoorhenButtonBar.js
+++ b/baby-gru/src/components/MoorhenButtonBar.js
@@ -9,49 +9,49 @@ export const MoorhenButtonBar = (props) => {
     const [selectedButtonIndex, setSelectedButtonIndex] = useState(null);
 
     const editButtons = [
-        (<MoorhenAutofitRotamerButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenAutofitRotamerButton {...props} key='auto-fit-rotamer' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="0" />),
 
-        (<MoorhenFlipPeptideButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenFlipPeptideButton {...props} key='flip-peptide' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="1" />),
 
-        (<MoorhenSideChain180Button {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenSideChain180Button {...props} key='side-chain-180' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="2" />),
 
-        (<MoorhenRefineResiduesUsingAtomCidButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenRefineResiduesUsingAtomCidButton {...props} key='refine-cid' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="3" />),
 
-        (<MoorhenDeleteUsingCidButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenDeleteUsingCidButton {...props} key='delete-cid' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="4" />),
 
-        (<MoorhenMutateButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenMutateButton {...props} key='mutate' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="5" />),
 
-        (<MoorhenAddTerminalResidueDirectlyUsingCidButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenAddTerminalResidueDirectlyUsingCidButton {...props} key='add-terminal-residue' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="6" />),
 
-        (<MoorhenEigenFlipLigandButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenEigenFlipLigandButton {...props} key='eigen-flip' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="7" />),
 
-        (<MoorhenJedFlipFalseButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenJedFlipFalseButton {...props} key='jed-flip-false' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="8" />),
 
-        (<MoorhenJedFlipTrueButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenJedFlipTrueButton {...props} key='jed-flip-true' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="9" />),
 
-        (<MoorhenRotateTranslateZoneButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenRotateTranslateZoneButton {...props} key='rotate-translate-zone' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="10" />),
 
-        (<MoorhenAddSimpleButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenAddSimpleButton {...props} key='add-simple' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="11" />),
         
-        (<MoorhenAddSideChainButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenAddSideChainButton {...props} key='add-side-chain' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="12" />),
         
-        /**(<MoorhenAddAltConfButton {...props} selectedButtonIndex={selectedButtonIndex}
+        /**(<MoorhenAddAltConfButton {...props} key='add-alt-conf' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="13" />),*/
     
-        (<MoorhenConvertCisTransButton {...props} selectedButtonIndex={selectedButtonIndex}
+        (<MoorhenConvertCisTransButton {...props} key='cis-trans' selectedButtonIndex={selectedButtonIndex}
                 setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="14" />),
 
     ]
@@ -99,12 +99,12 @@ export const MoorhenButtonBar = (props) => {
                 indicators={false} 
                 onSlide={() => setSelectedButtonIndex(-1)}
                 controls={carouselItems.length > 1}>
-                    {carouselItems.map(item => {
+                    {carouselItems.map((item, index) => {
                         return (
-                            <Carousel.Item>
-                            <ButtonGroup>
-                                {item}
-                            </ButtonGroup>
+                            <Carousel.Item key={index}>
+                                <ButtonGroup>
+                                    {item}
+                                </ButtonGroup>
                             </Carousel.Item>
                         )
                     })}

--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -42,26 +42,26 @@ export const MoorhenMapCard = (props) => {
     const actionButtons = {
         1: {
             label: cootContour ? "Hide map" : "Show map", 
-            compressed: () => {return (<MenuItem key={1} variant="success" onClick={handleVisibility}>{cootContour ? "Hide map" : "Show map"}</MenuItem>)},
-            expanded: () => {return (<Button size="sm" variant="outlined" onClick={handleVisibility}>
+            compressed: () => {return (<MenuItem key='hide-show-map' variant="success" onClick={handleVisibility}>{cootContour ? "Hide map" : "Show map"}</MenuItem>)},
+            expanded: () => {return (<Button key='hide-show-map' size="sm" variant="outlined" onClick={handleVisibility}>
                                         {cootContour ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
                                     </Button>)},
         },
         2: {
             label: "Download Map", 
-            compressed: () => {return (<MenuItem key={2} variant="success" onClick={handleDownload}>Download map</MenuItem>)},
-            expanded:  () => {return (<Button size="sm" variant="outlined" onClick={handleDownload}>
+            compressed: () => {return (<MenuItem key='donwload-map' variant="success" onClick={handleDownload}>Download map</MenuItem>)},
+            expanded:  () => {return (<Button key='donwload-map' size="sm" variant="outlined" onClick={handleDownload}>
                                         <DownloadOutlined />
                                       </Button> )},
         },
         3: {
             label: mapLitLines ? "Deactivate lit lines" : "Activate lit lines",
-            compressed: () => {return (<MenuItem key={3} variant="success" disabled={!cootContour}  onClick={handleLitLines}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>)},
+            compressed: () => {return (<MenuItem key='activate-deactivate-lit-lines' variant="success" disabled={!cootContour}  onClick={handleLitLines}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>)},
             expanded: null
         },
         4: {
             label: 'Rename map',
-            compressed: () => {return (<MoorhenRenameDisplayObjectMenuItem key={4} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />)},
+            compressed: () => {return (<MoorhenRenameDisplayObjectMenuItem key='rename-map' setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />)},
             expanded: null
         }
     }
@@ -87,13 +87,14 @@ export const MoorhenMapCard = (props) => {
 
         compressedButtons.push((
             <MoorhenDeleteDisplayObjectMenuItem 
+                key='delete-map'
                 setPopoverIsShown={setPopoverIsShown} 
                 glRef={props.glRef} 
                 changeItemList={props.changeMaps}
-                 itemList={props.maps} 
-                 item={props.map}
-                  setActiveMap={props.setActiveMap}
-                   activeMap={props.activeMap}/>
+                itemList={props.maps} 
+                item={props.map}
+                setActiveMap={props.setActiveMap}
+                activeMap={props.activeMap}/>
         ))
         
         return  <Fragment>

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -270,6 +270,7 @@ export const MoorhenMoleculeCard = (props) => {
                                                     )
                                                 }
                                                 return (<MoorhenSequenceViewer
+                                                    key={`${props.molecule.molNo}-${sequence.chain}`}
                                                     sequence={sequence}
                                                     molecule={props.molecule}
                                                     glRef={props.glRef}


### PR DESCRIPTION
This reduces the number of warnings printed in the console by assigning unique `key` prop values to some components inside lists.